### PR TITLE
Fix "Apply tags" error

### DIFF
--- a/src/visualizers/widgets/TagCreator/TagCreatorWidget.js
+++ b/src/visualizers/widgets/TagCreator/TagCreatorWidget.js
@@ -37,7 +37,10 @@ define([
       if (taxonomyPath) {
         renderData.addButton(
           "Apply tags",
-          (tags) => this.addTags(taxonomyPath, tags),
+          (tags) => {
+            this.form.setMissingDefaults(schema, tags);
+            this.addTags(taxonomyPath, tags);
+          },
           "btn-info"
         );
       }


### PR DESCRIPTION
calls `setMissingDefaults` when Tag Creator's "Apply tags" clicked

resolves #133