### PR TITLE
Differentiating btwn model errors and other errors. Close #92

### DIFF
--- a/src/routers/Search/Search.js
+++ b/src/routers/Search/Search.js
@@ -99,7 +99,6 @@ function initialize(middlewareOpts) {
           mainConfig
         );
         const artifacts = await storage.listArtifacts();
-        console.log({ artifacts });
         res.status(200).json(artifacts).end();
       } catch (e) {
         logger.error(e.stack);
@@ -127,7 +126,6 @@ function initialize(middlewareOpts) {
       );
 
       const status = await storage.createArtifact(metadata);
-      console.log(`about to send ${status} to client`);
       res.json(status);
     }
   );

--- a/src/routers/Search/Search.js
+++ b/src/routers/Search/Search.js
@@ -73,7 +73,7 @@ function initialize(middlewareOpts) {
 
   router.get(
     RouterUtils.getContentTypeRoutes("configuration.json"),
-    async (req, res) => {
+    RouterUtils.handleUserErrors(logger, async function (req, res) {
       const { core, contentType } = req.webgmeContext;
       const configuration = await DashboardConfiguration.from(
         core,
@@ -82,14 +82,14 @@ function initialize(middlewareOpts) {
       configuration.project = req.webgmeContext.projectVersion;
       configuration.contentTypePath = core.getPath(contentType);
       res.json(configuration);
-    }
+    })
   );
 
   // Accessing and updating data via the storage adapter
   router.get(
     RouterUtils.getContentTypeRoutes("artifacts/"),
     // TODO: add the artifact ID...
-    async function (req, res) {
+    RouterUtils.handleUserErrors(logger, async function (req, res) {
       try {
         const { core, contentType } = req.webgmeContext;
         const storage = await StorageAdapter.from(
@@ -104,13 +104,13 @@ function initialize(middlewareOpts) {
         logger.error(e.stack);
         res.sendStatus(401);
       }
-    }
+    })
   );
 
   router.post(
     RouterUtils.getContentTypeRoutes("artifacts/"),
     convertTaxonomyTags,
-    async function (req, res) {
+    RouterUtils.handleUserErrors(logger, async function (req, res) {
       const { metadata } = req.body;
       // FIXME: what if it isn't using the branch in the URL?
       metadata.taxonomy = {
@@ -127,13 +127,13 @@ function initialize(middlewareOpts) {
 
       const status = await storage.createArtifact(metadata);
       res.json(status);
-    }
+    })
   );
 
   router.post(
     RouterUtils.getContentTypeRoutes("artifacts/:parentId/append"),
     convertTaxonomyTags,
-    async function (req, res) {
+    RouterUtils.handleUserErrors(logger, async function (req, res) {
       const { parentId } = req.params;
       const { core, contentType } = req.webgmeContext;
       const storage = await StorageAdapter.from(
@@ -157,14 +157,14 @@ function initialize(middlewareOpts) {
         }
       });
       res.json(appendResult);
-    }
+    })
   );
 
   router.post(
     RouterUtils.getContentTypeRoutes(
       "artifacts/:parentId/:index/:fileId/upload"
     ),
-    async function (req, res) {
+    RouterUtils.handleUserErrors(logger, async function (req, res) {
       const { parentId, index, fileId } = req.params;
       const { core, contentType } = req.webgmeContext;
       const storage = await StorageAdapter.from(
@@ -176,12 +176,12 @@ function initialize(middlewareOpts) {
       // TODO: verify that it is a legitimate request
       const status = await storage.uploadFile(parentId, index, fileId, req);
       res.json(status);
-    }
+    })
   );
 
   router.get(
     RouterUtils.getContentTypeRoutes("artifacts/:parentId/download"),
-    async function (req, res) {
+    RouterUtils.handleUserErrors(logger, async function (req, res) {
       const { parentId } = req.params;
       // TODO: get the IDs for the specific observations to get
       let ids;
@@ -221,7 +221,7 @@ function initialize(middlewareOpts) {
         // no files associated with the artifact
         return res.sendStatus(204);
       }
-    }
+    })
   );
 
   logger.debug("ready");

--- a/src/routers/Search/adapters/MongoDB/index.js
+++ b/src/routers/Search/adapters/MongoDB/index.js
@@ -16,6 +16,7 @@ const { promisify } = require("util");
 const streamPipeline = promisify(pipeline);
 const DownloadFile = require("../common/DownloadFile");
 const { Artifact, ArtifactSet } = require("../common/Artifact");
+const ModelError = require('../common/ModelError');
 
 const mongoUri = require("../../../../../config").mongo.uri;
 const { MongoClient, GridFSBucket, ObjectId } = require("mongodb");
@@ -171,7 +172,10 @@ class MongoAdapter extends Adapter {
   static from(core, storageNode) {
     const baseUrl = core.getAttribute(storageNode, "URI");
     const collection = core.getAttribute(storageNode, "collection");
-    // TODO: throw an error if the collection is not provided
+    if (!collection) {
+      const msg = 'No MongoDB collection specified';
+      throw new ModelError(core.getPath(storageNode), msg);
+    }
     return new MongoAdapter(baseUrl, collection);
   }
 }

--- a/src/routers/Search/adapters/PDP/index.js
+++ b/src/routers/Search/adapters/PDP/index.js
@@ -17,6 +17,7 @@ const { pipeline } = require("stream");
 const { promisify } = require("util");
 const streamPipeline = promisify(pipeline);
 const DownloadFile = require("../common/DownloadFile");
+const { MissingAttributeError } = require("../common/ModelError");
 const { Artifact, ArtifactSet } = require("../common/Artifact");
 const CreateRequestLogger = require("./CreateRequestLogger");
 const logFilePath = process.env.CREATE_LOG_PATH || "./CreateProcesses.jsonl";
@@ -430,8 +431,10 @@ class PDP {
     const processType = core.getAttribute(storageNode, "processType");
 
     if (!baseUrl) {
-      const msg = 'PDP URL specified for PDP';
-      throw new ModelError(core.getPath(storageNode), msg);
+      throw new MissingAttributeError(core, storageNode, "URL");
+    }
+    if (!processType) {
+      throw new MissingAttributeError(core, storageNode, "processType");
     }
     return new PDP(baseUrl, token, processType);
   }

--- a/src/routers/Search/adapters/PDP/index.js
+++ b/src/routers/Search/adapters/PDP/index.js
@@ -428,6 +428,11 @@ class PDP {
 
     const baseUrl = core.getAttribute(storageNode, "URL");
     const processType = core.getAttribute(storageNode, "processType");
+
+    if (!baseUrl) {
+      const msg = 'PDP URL specified for PDP';
+      throw new ModelError(core.getPath(storageNode), msg);
+    }
     return new PDP(baseUrl, token, processType);
   }
 }

--- a/src/routers/Search/adapters/common/ModelError.js
+++ b/src/routers/Search/adapters/common/ModelError.js
@@ -1,8 +1,33 @@
-class ModelError extends Error {
+const { UserError } = require("../../../common/routers/Utils");
+const UNPROCESSABLE_ENTITY = 422;
+
+class ModelError extends UserError {
   constructor(nodeId, msg) {
-    super(msg);
+    super(msg, UNPROCESSABLE_ENTITY);
     this.nodeId = nodeId;
+  }
+
+  sendVia(response) {
+    response.status(this.statusCode).json(JSON.stringify(this));
   }
 }
 
-module.exports = ModelError;
+class MissingAttributeError extends ModelError {
+  constructor(core, node, attrName) {
+    const nodeId = core.getPath(node);
+    const name = core.getAttribute(node, "name");
+    const msg = `No ${attrName} specified for ${name}`;
+    super(nodeId, msg);
+  }
+}
+
+class StorageNotFoundError extends ModelError {
+  constructor(core, contentTypeNode) {
+    const nodeId = core.getPath(contentTypeNode);
+    const name = core.getAttribute(contentTypeNode, "name");
+    const msg = `No storage configured for ${name}`;
+    super(nodeId, msg);
+  }
+}
+
+module.exports = { ModelError, StorageNotFoundError, MissingAttributeError };

--- a/src/routers/Search/adapters/common/ModelError.js
+++ b/src/routers/Search/adapters/common/ModelError.js
@@ -1,0 +1,8 @@
+class ModelError extends Error {
+  constructor(nodeId, msg) {
+    super(msg);
+    this.nodeId = nodeId;
+  }
+}
+
+module.exports = ModelError;

--- a/src/routers/Search/adapters/index.js
+++ b/src/routers/Search/adapters/index.js
@@ -1,6 +1,7 @@
 // TODO: load the different adapter types
 
 const RouterUtils = require("../../../common/routers/Utils");
+const { StorageNotFoundError } = require("./common/ModelError");
 const fs = require("fs");
 const SUPPORTED_ADAPTERS = Object.fromEntries(
   fs
@@ -15,6 +16,10 @@ class Adapters {
     const storageNode = (await core.loadChildren(contentTypeNode)).find(
       (child) => isTypeOf(core, child, "Storage")
     );
+
+    if (!storageNode) {
+      throw new StorageNotFoundError(core, contentTypeNode);
+    }
 
     const adapterType = core.getAttribute(
       core.getMetaType(storageNode),


### PR DESCRIPTION
This is still a work in progress. This PR adds a new type of error, `ModelError`, which is sent to the client as a JSON object that includes a message and the node ID in question. This should allow the client to display an error message with an easy way to "click to view" (opening the node in question in the taxonomy design studio).

Concretely, the current PR contains code to check for common `ModelError`s and then send them as JSON to the client (using status code for "unprocessable entity"). 
To Do:
- [ ] detect the error on the client side
- [ ] add "click to view" fn-ality to the client to open the node in question