### PR TITLE
Use correct format URL in dashboard

### DIFF
--- a/src/routers/Search/dashboard/src/Formatter.ts
+++ b/src/routers/Search/dashboard/src/Formatter.ts
@@ -4,7 +4,7 @@ export default class TagFormatter {
   constructor() {
     this.baseUrl = window.location.href
       .replace("Search", "TagFormat")
-      .replace(/static.*$/, "human");
+      .replace(/[^\/]+\/static.*$/, "human");
   }
 
   async toHumanFormat(tags: any[]) {


### PR DESCRIPTION
Strip the content type from the format endpoint since it is project scoped. (It uses the entire taxonomy for the conversion - not just the select vocabularies for the content type.)