### PR TITLE
Fix downloads

### DIFF
--- a/src/common/routers/Utils.js
+++ b/src/common/routers/Utils.js
@@ -139,8 +139,8 @@ const Utils = {
 function handleUserErrors(logger, fn) {
   return async function (req, res, next) {
     try {
-      await fn(req, res, next);
-      if (!res.headersSent) {
+      const cont = await fn(req, res, next) ?? true;
+      if (cont && !res.headersSent) {
         next();
       }
     } catch (e) {

--- a/src/routers/Search/Search.js
+++ b/src/routers/Search/Search.js
@@ -206,6 +206,7 @@ function initialize(middlewareOpts) {
         return false;
       } catch (err) {
         // no files associated with the artifact
+        logger.error(err);
         res.sendStatus(204);
       }
     })

--- a/src/routers/Search/Search.js
+++ b/src/routers/Search/Search.js
@@ -27,6 +27,7 @@ const staticPath = path.join(__dirname, "dashboard", "public");
 const os = require("os");
 const { zip, COMPRESSION_LEVEL } = require("zip-a-folder");
 const fsp = require("fs/promises");
+const fs = require("fs");
 
 const StorageAdapter = require("./adapters");
 let mainConfig = null;
@@ -199,7 +200,7 @@ function initialize(middlewareOpts) {
       await fsp.rm(downloadDir, { recursive: true });
 
       try {
-        await fsp.access(zipPath, fsp.constants.R_OK);
+        await fsp.access(zipPath, fs.constants.R_OK);
         res.download(zipPath, path.basename(zipPath), () =>
           fsp.rm(tmpDir, { recursive: true })
         );

--- a/src/routers/Search/Search.js
+++ b/src/routers/Search/Search.js
@@ -200,12 +200,13 @@ function initialize(middlewareOpts) {
 
       try {
         await fsp.access(zipPath, fsp.constants.R_OK);
-        return res.download(zipPath, path.basename(zipPath), () =>
+        res.download(zipPath, path.basename(zipPath), () =>
           fsp.rm(tmpDir, { recursive: true })
         );
+        return false;
       } catch (err) {
         // no files associated with the artifact
-        return res.sendStatus(204);
+        res.sendStatus(204);
       }
     })
   );

--- a/src/routers/Search/dashboard/src/Utils.ts
+++ b/src/routers/Search/dashboard/src/Utils.ts
@@ -96,10 +96,7 @@ export function capitalize(word: string): string {
 }
 
 export function openUrl(url: string) {
-    const anchor = document.createElement("a");
-    anchor.setAttribute("href", url);
-    anchor.setAttribute("target", "_blank");
-    anchor.click();
+  return window.open(url, '_blank');
 }
 
 export function encodeQueryParams(dict: {[key: string]: string}) {


### PR DESCRIPTION
@brollb @yogeshVU - I hope this should fix downloads not working (at least it did for me locally).

The issue seemed to be that calling `res.download` was not changing the value of `res.headersSent`, even though it does appear to send headers. So `handleUserErrors` was then calling `next`, which would try to change headers and throw an error. I added the ability for the `handleUserErrors`'s function arg to return false, which basically tells it to skip calling `next` even if it thinks headers aren't sent.