### PR TITLE
fix empty `anyOf` schema error

### DIFF
--- a/src/common/JSONSchemaExporter.js
+++ b/src/common/JSONSchemaExporter.js
@@ -313,6 +313,10 @@ function factory() {
      */
     async _getAnyOfSchema(node) {
       const children = await this.core.loadChildren(node);
+      if (!children.length) {
+        return { type: "null" };
+      }
+
       const childSchemas = await Promise.all(
         children.map((c) => this.getFieldSchema(c))
       );


### PR DESCRIPTION
returns`null` type for empty `anyOf` schemas

This should fix the server crash being experienced when opening the tag creator. The instance we saw was actually being cause by an enum term with no associated children.  This line (`default: this._getDefault(childSchemas[0])`) was throwing an error because `childSchemas[0]` is `undefined`. I tried just not setting a `default` in this case. That fixed the server error, but then there were still schema validation errors on the tag creator page because `anyof` can't be empty. The easiest solution seemes to just set the field's type to `null` (instead of using an `anyOf`), because then it still shows the term in the tag creator, but just doesn't allow you to set anything for it.