### PR TITLE
Address issue with `FilterTag` matching

### DIFF
--- a/src/routers/Search/dashboard/src/TagMatcher.ts
+++ b/src/routers/Search/dashboard/src/TagMatcher.ts
@@ -18,7 +18,7 @@ const fuseOptions: Fuse.IFuseOptions<any> = {
  */
 export default function (valueId: string, tags: ItemTag[]) {
   const list = tags
-    .map(tag => ItemTag.valueForId(tag, valueId))
+    .map(tag => ItemTag.valueForKey(tag, valueId))
     .sort()
     .filter((val, index, sorted) => (val != null) && (val !== sorted[index - 1]));
 

--- a/src/routers/Search/dashboard/src/Utils.ts
+++ b/src/routers/Search/dashboard/src/Utils.ts
@@ -105,6 +105,10 @@ export function encodeQueryParams(dict: {[key: string]: string}) {
     .join('&');
 }
 
-export function isObject(thing) {
+export function isObject(thing: any) {
   return typeof thing === 'object' && !Array.isArray(thing);
+}
+
+export function isDefined(thing: any) {
+  return (thing != null) || (thing === null);
 }

--- a/src/routers/Search/dashboard/src/Utils.ts
+++ b/src/routers/Search/dashboard/src/Utils.ts
@@ -105,10 +105,10 @@ export function encodeQueryParams(dict: {[key: string]: string}) {
     .join('&');
 }
 
-export function isObject(thing: any) {
+export function isObject<T>(thing: T): thing is Exclude<T, undefined | string | number | boolean | Array<any> | Function> {
   return typeof thing === 'object' && !Array.isArray(thing);
 }
 
-export function isDefined(thing: any) {
+export function isDefined<T>(thing: T): thing is Exclude<T, undefined> {
   return (thing != null) || (thing === null);
 }

--- a/src/routers/Search/dashboard/src/tags/FilterTag.ts
+++ b/src/routers/Search/dashboard/src/tags/FilterTag.ts
@@ -44,11 +44,10 @@ export default class FilterTag<T extends string = string> {
   }
 
   isMatch(itemTag: ItemTag) {
-    if (!isDefined(this.value)) {
-      return true;
-    }
     const value = ItemTag.valueForKey(itemTag, this.id);
-    return  (this.value === value);
+    return !isDefined(this.value)
+      ? isDefined(value)
+      : (this.value === value);
   }
 
   lean(): LeanTag {

--- a/src/routers/Search/dashboard/src/tags/FilterTag.ts
+++ b/src/routers/Search/dashboard/src/tags/FilterTag.ts
@@ -39,7 +39,8 @@ export default class FilterTag<T extends string = string> {
   }
 
   canMatch(itemTag: ItemTag) {
-    return (itemTag.ID === this.id) || itemTag.hasOwnProperty(this.id);
+    const value = ItemTag.valueForKey(itemTag, this.id);
+    return isDefined(value);
   }
 
   isMatch(itemTag: ItemTag) {

--- a/src/routers/Search/dashboard/src/tags/FilterTag.ts
+++ b/src/routers/Search/dashboard/src/tags/FilterTag.ts
@@ -1,5 +1,6 @@
-import type ItemTag from "./ItemTag";
+import ItemTag from "./ItemTag";
 import LeanTag from "./LeanTag";
+import { isDefined } from "../Utils";
 
 /*
  * A FilterTag is a tag that can be used to filter the search results.
@@ -42,35 +43,15 @@ export default class FilterTag<T extends string = string> {
   }
 
   isMatch(itemTag: ItemTag) {
-    const value = getItemTagValue(itemTag, this.id);
-    let matched = this.value ? this.value === value : !!value;
-    return matched;
+    if (!isDefined(this.value)) {
+      return true;
+    }
+    const value = ItemTag.valueForKey(itemTag, this.id);
+    console.log("Filter Tag match value:", value);
+    return  (this.value === value);
   }
 
   lean(): LeanTag {
     return new LeanTag(this.id, this.value);
   }
-}
-
-function getItemTagValue(itemTag: ItemTag, key: string) {
-  const keys = Object.keys(itemTag);
-  if (keys.includes(key)) {
-    return itemTag[key];
-  }
-
-  const value = Object.values(itemTag)
-    .filter((v) => typeof v === "object")
-    .find((v) => getItemTagValue(v, key));
-
-  return value;
-}
-
-function itemIDs(itemTag: ItemTag) {
-  return Object.entries(itemTag).flatMap(([k, v]) => {
-    const keys = [k];
-    if (typeof v === "object") {
-      keys.push(...itemIDs(v));
-    }
-    return keys;
-  });
 }

--- a/src/routers/Search/dashboard/src/tags/FilterTag.ts
+++ b/src/routers/Search/dashboard/src/tags/FilterTag.ts
@@ -38,6 +38,10 @@ export default class FilterTag<T extends string = string> {
     return path;
   }
 
+  isLabel() {
+    return !isDefined(this.value)
+  }
+
   canMatch(itemTag: ItemTag) {
     const value = ItemTag.valueForKey(itemTag, this.id);
     return isDefined(value);
@@ -45,9 +49,9 @@ export default class FilterTag<T extends string = string> {
 
   isMatch(itemTag: ItemTag) {
     const value = ItemTag.valueForKey(itemTag, this.id);
-    return !isDefined(this.value)
-      ? isDefined(value)
-      : (this.value === value);
+    const foundTag = isDefined(value);
+    const tagValuesMatch = (this.value === value);
+    return this.isLabel ? foundTag : tagValuesMatch;
   }
 
   lean(): LeanTag {

--- a/src/routers/Search/dashboard/src/tags/FilterTag.ts
+++ b/src/routers/Search/dashboard/src/tags/FilterTag.ts
@@ -48,7 +48,6 @@ export default class FilterTag<T extends string = string> {
       return true;
     }
     const value = ItemTag.valueForKey(itemTag, this.id);
-    console.log("Filter Tag match value:", value);
     return  (this.value === value);
   }
 

--- a/src/routers/Search/dashboard/src/tags/ItemTag.ts
+++ b/src/routers/Search/dashboard/src/tags/ItemTag.ts
@@ -1,11 +1,23 @@
+import { isObject, isDefined } from "../Utils";
+
 interface ItemTag {
   ID: string;
   value: any;
 }
   
 namespace ItemTag {
-  export function valueForId(itemTag: ItemTag, id: string) {
-    return (itemTag.ID === id) ? itemTag.value : itemTag[id];
+  export function valueForKey(itemTag: ItemTag, key: string) {
+    if (itemTag.hasOwnProperty(key)) {
+      return itemTag[key];
+    }
+    let value: any;
+    Object.values(itemTag)
+      .filter(isObject)
+      .some(obj => {
+        value = valueForKey(obj, key);
+        return isDefined(value);
+      });
+    return value;
   }
 }
 

--- a/src/routers/Search/dashboard/src/tags/SetFilterTag.ts
+++ b/src/routers/Search/dashboard/src/tags/SetFilterTag.ts
@@ -16,7 +16,7 @@ export default class SetFilterTag extends FilterTag<"SetField"> {
    */
   override isMatch(itemTag: ItemTag): boolean {
     const filterValue = this.value ?? [];
-    const itemValue = (ItemTag.valueForId(itemTag, this.id) ?? [])
+    const itemValue = (ItemTag.valueForKey(itemTag, this.id) ?? [])
       .map(item => item.ID);
     return arraysEqual(filterValue, itemValue, { ignoreOrder: true });
   }


### PR DESCRIPTION
Addressing issues mentioned by @brollb on commit https://github.com/webgme/webgme-taxonomy/commit/125f6c5ecfc75e853887c403fcc5606b00102b30 .

@brollb does this look correct? Also, is this check no longer needed in `isMatch`?
```typescript
let matched = (itemTag.ID === this.id) && (itemTag.value == this.value);
```

