### PR TITLE
Show dashboard artifact set selection

### DIFF
--- a/src/routers/Search/dashboard/src/App.svelte
+++ b/src/routers/Search/dashboard/src/App.svelte
@@ -498,7 +498,10 @@
       {#if items.length}
         <List twoLine avatarList>
           {#each items as item (item.hash)}
-            <Item on:SMUI:action={() => onItemClicked(item)}>
+            <Item
+              selected={item === selectedArtifactSet}
+              on:SMUI:action={() => onItemClicked(item)}
+            >
               <Text>
                 <PrimaryText>{item.displayName}</PrimaryText>
                 <SecondaryText />


### PR DESCRIPTION
When an artifact set is selected, then you click somewhere else, so that list item loses focus, it now remains highlighted:

![Screen Shot 2023-02-06 at 5 39 05 PM](https://user-images.githubusercontent.com/1537672/217111859-ca4dc7f8-d5c4-4fa5-b661-15c634c54283.png)

Then if you do something, such as selecting a filter that clears that artifact set from being shown on the far right, then the highlight is removed:

![Screen Shot 2023-02-06 at 5 39 30 PM](https://user-images.githubusercontent.com/1537672/217111979-262123af-ef4b-4039-bfda-05ba6cb8d7e7.png)

resolves #139 