### PR TITLE
update "webgme-json-importer" dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "webgme-taxonomy",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webgme-taxonomy",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "mongodb": "^4.11.0",
         "node-fetch": "^2.6.6",
         "svelte": "^3.50.0",
         "webgme": "github:webgme/webgme#azure",
-        "webgme-json-importer": "github:deepforge-dev/webgme-json-importer",
+        "webgme-json-importer": "^1.4.1",
         "zip-a-folder": "^1.1.5"
       },
       "devDependencies": {
@@ -9931,9 +9931,9 @@
       }
     },
     "node_modules/webgme-json-importer": {
-      "version": "1.3.1",
-      "resolved": "git+ssh://git@github.com/deepforge-dev/webgme-json-importer.git#89a72542a7daa8255f003ed167ccf3292c5f6fa0",
-      "integrity": "sha512-LFPDTp1OB6HmmBdmcYf1BMok86RgtMr4qhU9ZpKaPLbsGtJQ/mYJ6ZBUOkt65v673TuQbQNjoozsnmcya4nwzA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/webgme-json-importer/-/webgme-json-importer-1.4.1.tgz",
+      "integrity": "sha512-xIhDfih095LjX/Qd38pqdWcyS/nnkTO45D9zZlhBMfbH4C4xiwuk/2gySR9F9E6kjxmuJYohpnJAobH0hHG65Q==",
       "peerDependencies": {
         "webgme": "^2.23.0"
       }
@@ -19169,9 +19169,9 @@
       }
     },
     "webgme-json-importer": {
-      "version": "git+ssh://git@github.com/deepforge-dev/webgme-json-importer.git#89a72542a7daa8255f003ed167ccf3292c5f6fa0",
-      "integrity": "sha512-LFPDTp1OB6HmmBdmcYf1BMok86RgtMr4qhU9ZpKaPLbsGtJQ/mYJ6ZBUOkt65v673TuQbQNjoozsnmcya4nwzA==",
-      "from": "webgme-json-importer@github:deepforge-dev/webgme-json-importer",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/webgme-json-importer/-/webgme-json-importer-1.4.1.tgz",
+      "integrity": "sha512-xIhDfih095LjX/Qd38pqdWcyS/nnkTO45D9zZlhBMfbH4C4xiwuk/2gySR9F9E6kjxmuJYohpnJAobH0hHG65Q==",
       "requires": {}
     },
     "webgme-ot": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "node-fetch": "^2.6.6",
     "svelte": "^3.50.0",
     "webgme": "github:webgme/webgme#azure",
-    "webgme-json-importer": "github:deepforge-dev/webgme-json-importer",
+    "webgme-json-importer": "^1.4.1",
     "zip-a-folder": "^1.1.5"
   },
   "lint-staged": {


### PR DESCRIPTION
Updates "webgme-json-importer" dependency to use npm instead of GitHub. This should also update the version to  resolve the umd build issue.

resolves #190