### PR TITLE
Add filePattern to capture all files regardless of ext. Close #203

### DIFF
--- a/src/routers/Search/src/adapters/PDP/index.ts
+++ b/src/routers/Search/src/adapters/PDP/index.ts
@@ -137,6 +137,7 @@ export default class PDP implements Adapter {
       obsIndex: obsIndex.toString(),
       version: version.toString(),
       endObsIndex: obsIndex.toString(),
+      filePattern: "**/**",
     };
     const url = PDP._addQueryParams("v3/Files/GetObservationFiles", queryDict);
     const opts = {


### PR DESCRIPTION
This adds a wildcard file pattern argument as suggested by @yogeshVU
