### PR TITLE
Add dockerfile and GA for building, pushing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,40 @@
+name: Push Docker Hub
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+        
+      - name: Get Release Tags
+        id: get_release_tags
+        run: |
+          echo "RELEASE_TAG=$(echo ${GITHUB_REF} | sed -E 's/.*v?([0-9]+)\.([0-9]+)\.([0-9]+)?/\1.\2.\3,\1.\2,\1/')" >> $GITHUB_ENV
+          echo "TAG=stable" >> $GITHUB_ENV
+        if: github.event_name == 'release'
+
+      - name: Get Push Tags
+        id: get_push_tags
+        run: |
+          echo "RELEASE_TAG=$(echo ${GITHUB_REF:11})" >> $GITHUB_ENV
+          echo "TAG=latest" >> $GITHUB_ENV
+        if: github.event_name == 'push'
+        
+      - name: Publish to Docker Hub
+        uses: elgohr/Publish-Docker-Github-Action@v4
+        with:
+          name: webgme/taxonomy
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          tags: "${{ env.TAG }},${{ env.RELEASE_TAG }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:lts
+MAINTAINER Brian Broll <brian.broll@vanderbilt.edu>
+
+ADD . /webgme-taxonomy
+WORKDIR /webgme-taxonomy
+RUN npm i --legacy-peer-deps  # Needed until webgme dependency is updated to official release
+
+CMD ["npm", "start"]


### PR DESCRIPTION
This adds a dockerfile and github action for building and pushing the docker image to dockerhub.

The action is expected to fail until we add the required secrets for pushing to the webgme user's account.
