### PR TITLE
Fix dashboard flicker

### DIFF
--- a/src/routers/Dashboard/app/package-lock.json
+++ b/src/routers/Dashboard/app/package-lock.json
@@ -4166,7 +4166,8 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.0.tgz",
       "integrity": "sha512-Aw21SsyoohyVn4yiKXWPNCSW2DQNH/76kvUnE9kpt4h9hcg9tfyQc6xshx9hzgMfGF0kVx0EGD8oBMWSnATeOg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "svelte-preprocess": {
       "version": "4.10.7",

--- a/src/routers/Search/dashboard/package-lock.json
+++ b/src/routers/Search/dashboard/package-lock.json
@@ -2681,17 +2681,17 @@
       }
     },
     "node_modules/@smui/card/node_modules/svelte": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-      "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+      "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@jridgewell/trace-mapping": "^0.3.18",
-        "acorn": "^8.8.2",
-        "aria-query": "^5.2.1",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
         "axobject-query": "^3.2.1",
         "code-red": "^1.0.3",
         "css-tree": "^2.3.1",
@@ -2720,9 +2720,9 @@
       }
     },
     "node_modules/@smui/card/node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -2919,17 +2919,17 @@
       }
     },
     "node_modules/@smui/checkbox/node_modules/svelte": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-      "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+      "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@jridgewell/trace-mapping": "^0.3.18",
-        "acorn": "^8.8.2",
-        "aria-query": "^5.2.1",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
         "axobject-query": "^3.2.1",
         "code-red": "^1.0.3",
         "css-tree": "^2.3.1",
@@ -2958,9 +2958,9 @@
       }
     },
     "node_modules/@smui/checkbox/node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -3120,17 +3120,17 @@
       }
     },
     "node_modules/@smui/chips/node_modules/svelte": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-      "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+      "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@jridgewell/trace-mapping": "^0.3.18",
-        "acorn": "^8.8.2",
-        "aria-query": "^5.2.1",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
         "axobject-query": "^3.2.1",
         "code-red": "^1.0.3",
         "css-tree": "^2.3.1",
@@ -3159,9 +3159,9 @@
       }
     },
     "node_modules/@smui/chips/node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -3506,17 +3506,17 @@
       }
     },
     "node_modules/@smui/dialog/node_modules/svelte": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-      "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+      "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@jridgewell/trace-mapping": "^0.3.18",
-        "acorn": "^8.8.2",
-        "aria-query": "^5.2.1",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
         "axobject-query": "^3.2.1",
         "code-red": "^1.0.3",
         "css-tree": "^2.3.1",
@@ -3545,9 +3545,9 @@
       }
     },
     "node_modules/@smui/dialog/node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -3640,17 +3640,17 @@
       }
     },
     "node_modules/@smui/drawer/node_modules/svelte": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-      "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+      "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@jridgewell/trace-mapping": "^0.3.18",
-        "acorn": "^8.8.2",
-        "aria-query": "^5.2.1",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
         "axobject-query": "^3.2.1",
         "code-red": "^1.0.3",
         "css-tree": "^2.3.1",
@@ -3679,9 +3679,9 @@
       }
     },
     "node_modules/@smui/drawer/node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -3817,17 +3817,17 @@
       }
     },
     "node_modules/@smui/form-field/node_modules/svelte": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-      "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+      "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@jridgewell/trace-mapping": "^0.3.18",
-        "acorn": "^8.8.2",
-        "aria-query": "^5.2.1",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
         "axobject-query": "^3.2.1",
         "code-red": "^1.0.3",
         "css-tree": "^2.3.1",
@@ -3856,9 +3856,9 @@
       }
     },
     "node_modules/@smui/form-field/node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -4071,17 +4071,17 @@
       }
     },
     "node_modules/@smui/icon-button/node_modules/svelte": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-      "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+      "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@jridgewell/trace-mapping": "^0.3.18",
-        "acorn": "^8.8.2",
-        "aria-query": "^5.2.1",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
         "axobject-query": "^3.2.1",
         "code-red": "^1.0.3",
         "css-tree": "^2.3.1",
@@ -4110,9 +4110,9 @@
       }
     },
     "node_modules/@smui/icon-button/node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -4362,17 +4362,17 @@
       }
     },
     "node_modules/@smui/list/node_modules/svelte": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-      "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+      "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@jridgewell/trace-mapping": "^0.3.18",
-        "acorn": "^8.8.2",
-        "aria-query": "^5.2.1",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
         "axobject-query": "^3.2.1",
         "code-red": "^1.0.3",
         "css-tree": "^2.3.1",
@@ -4401,9 +4401,9 @@
       }
     },
     "node_modules/@smui/list/node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -4672,17 +4672,17 @@
       }
     },
     "node_modules/@smui/menu/node_modules/svelte": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-      "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+      "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@jridgewell/trace-mapping": "^0.3.18",
-        "acorn": "^8.8.2",
-        "aria-query": "^5.2.1",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
         "axobject-query": "^3.2.1",
         "code-red": "^1.0.3",
         "css-tree": "^2.3.1",
@@ -4711,9 +4711,9 @@
       }
     },
     "node_modules/@smui/menu/node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -4896,17 +4896,17 @@
       }
     },
     "node_modules/@smui/radio/node_modules/svelte": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-      "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+      "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@jridgewell/trace-mapping": "^0.3.18",
-        "acorn": "^8.8.2",
-        "aria-query": "^5.2.1",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
         "axobject-query": "^3.2.1",
         "code-red": "^1.0.3",
         "css-tree": "^2.3.1",
@@ -4935,9 +4935,9 @@
       }
     },
     "node_modules/@smui/radio/node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -5351,17 +5351,17 @@
       }
     },
     "node_modules/@smui/select/node_modules/svelte": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-      "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+      "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@jridgewell/trace-mapping": "^0.3.18",
-        "acorn": "^8.8.2",
-        "aria-query": "^5.2.1",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
         "axobject-query": "^3.2.1",
         "code-red": "^1.0.3",
         "css-tree": "^2.3.1",
@@ -5390,9 +5390,9 @@
       }
     },
     "node_modules/@smui/select/node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -5671,17 +5671,17 @@
       }
     },
     "node_modules/@smui/snackbar/node_modules/svelte": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-      "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+      "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@jridgewell/trace-mapping": "^0.3.18",
-        "acorn": "^8.8.2",
-        "aria-query": "^5.2.1",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
         "axobject-query": "^3.2.1",
         "code-red": "^1.0.3",
         "css-tree": "^2.3.1",
@@ -5710,9 +5710,9 @@
       }
     },
     "node_modules/@smui/snackbar/node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -6036,17 +6036,17 @@
       }
     },
     "node_modules/@smui/textfield/node_modules/svelte": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-      "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+      "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@jridgewell/trace-mapping": "^0.3.18",
-        "acorn": "^8.8.2",
-        "aria-query": "^5.2.1",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
         "axobject-query": "^3.2.1",
         "code-red": "^1.0.3",
         "css-tree": "^2.3.1",
@@ -6075,9 +6075,9 @@
       }
     },
     "node_modules/@smui/textfield/node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -6180,17 +6180,17 @@
       }
     },
     "node_modules/@smui/top-app-bar/node_modules/svelte": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-      "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+      "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
         "@jridgewell/trace-mapping": "^0.3.18",
-        "acorn": "^8.8.2",
-        "aria-query": "^5.2.1",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
         "axobject-query": "^3.2.1",
         "code-red": "^1.0.3",
         "css-tree": "^2.3.1",
@@ -6219,9 +6219,9 @@
       }
     },
     "node_modules/@smui/top-app-bar/node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -6379,9 +6379,9 @@
       "peer": true
     },
     "node_modules/aria-query": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.2.1.tgz",
-      "integrity": "sha512-7uFg4b+lETFgdaJyETnILsXgnnzVnkHcgRbwbPwevm5x/LmUlt3MjczMRe1zg824iBgXZNRPTBftNYyRSKLp2g==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -12010,17 +12010,17 @@
           }
         },
         "svelte": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-          "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+          "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
           "dev": true,
           "peer": true,
           "requires": {
             "@ampproject/remapping": "^2.2.1",
             "@jridgewell/sourcemap-codec": "^1.4.15",
             "@jridgewell/trace-mapping": "^0.3.18",
-            "acorn": "^8.8.2",
-            "aria-query": "^5.2.1",
+            "acorn": "^8.9.0",
+            "aria-query": "^5.3.0",
             "axobject-query": "^3.2.1",
             "code-red": "^1.0.3",
             "css-tree": "^2.3.1",
@@ -12042,9 +12042,9 @@
           }
         },
         "typescript": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-          "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+          "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
           "dev": true,
           "peer": true
         }
@@ -12233,17 +12233,17 @@
           }
         },
         "svelte": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-          "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+          "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
           "dev": true,
           "peer": true,
           "requires": {
             "@ampproject/remapping": "^2.2.1",
             "@jridgewell/sourcemap-codec": "^1.4.15",
             "@jridgewell/trace-mapping": "^0.3.18",
-            "acorn": "^8.8.2",
-            "aria-query": "^5.2.1",
+            "acorn": "^8.9.0",
+            "aria-query": "^5.3.0",
             "axobject-query": "^3.2.1",
             "code-red": "^1.0.3",
             "css-tree": "^2.3.1",
@@ -12265,9 +12265,9 @@
           }
         },
         "typescript": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-          "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+          "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
           "dev": true,
           "peer": true
         }
@@ -12419,17 +12419,17 @@
           }
         },
         "svelte": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-          "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+          "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
           "dev": true,
           "peer": true,
           "requires": {
             "@ampproject/remapping": "^2.2.1",
             "@jridgewell/sourcemap-codec": "^1.4.15",
             "@jridgewell/trace-mapping": "^0.3.18",
-            "acorn": "^8.8.2",
-            "aria-query": "^5.2.1",
+            "acorn": "^8.9.0",
+            "aria-query": "^5.3.0",
             "axobject-query": "^3.2.1",
             "code-red": "^1.0.3",
             "css-tree": "^2.3.1",
@@ -12451,9 +12451,9 @@
           }
         },
         "typescript": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-          "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+          "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
           "dev": true,
           "peer": true
         }
@@ -12794,17 +12794,17 @@
           }
         },
         "svelte": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-          "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+          "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
           "dev": true,
           "peer": true,
           "requires": {
             "@ampproject/remapping": "^2.2.1",
             "@jridgewell/sourcemap-codec": "^1.4.15",
             "@jridgewell/trace-mapping": "^0.3.18",
-            "acorn": "^8.8.2",
-            "aria-query": "^5.2.1",
+            "acorn": "^8.9.0",
+            "aria-query": "^5.3.0",
             "axobject-query": "^3.2.1",
             "code-red": "^1.0.3",
             "css-tree": "^2.3.1",
@@ -12826,9 +12826,9 @@
           }
         },
         "typescript": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-          "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+          "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
           "dev": true,
           "peer": true
         }
@@ -12913,17 +12913,17 @@
           }
         },
         "svelte": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-          "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+          "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
           "dev": true,
           "peer": true,
           "requires": {
             "@ampproject/remapping": "^2.2.1",
             "@jridgewell/sourcemap-codec": "^1.4.15",
             "@jridgewell/trace-mapping": "^0.3.18",
-            "acorn": "^8.8.2",
-            "aria-query": "^5.2.1",
+            "acorn": "^8.9.0",
+            "aria-query": "^5.3.0",
             "axobject-query": "^3.2.1",
             "code-red": "^1.0.3",
             "css-tree": "^2.3.1",
@@ -12945,9 +12945,9 @@
           }
         },
         "typescript": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-          "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+          "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
           "dev": true,
           "peer": true
         }
@@ -13075,17 +13075,17 @@
           }
         },
         "svelte": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-          "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+          "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
           "dev": true,
           "peer": true,
           "requires": {
             "@ampproject/remapping": "^2.2.1",
             "@jridgewell/sourcemap-codec": "^1.4.15",
             "@jridgewell/trace-mapping": "^0.3.18",
-            "acorn": "^8.8.2",
-            "aria-query": "^5.2.1",
+            "acorn": "^8.9.0",
+            "aria-query": "^5.3.0",
             "axobject-query": "^3.2.1",
             "code-red": "^1.0.3",
             "css-tree": "^2.3.1",
@@ -13107,9 +13107,9 @@
           }
         },
         "typescript": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-          "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+          "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
           "dev": true,
           "peer": true
         }
@@ -13314,17 +13314,17 @@
           }
         },
         "svelte": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-          "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+          "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
           "dev": true,
           "peer": true,
           "requires": {
             "@ampproject/remapping": "^2.2.1",
             "@jridgewell/sourcemap-codec": "^1.4.15",
             "@jridgewell/trace-mapping": "^0.3.18",
-            "acorn": "^8.8.2",
-            "aria-query": "^5.2.1",
+            "acorn": "^8.9.0",
+            "aria-query": "^5.3.0",
             "axobject-query": "^3.2.1",
             "code-red": "^1.0.3",
             "css-tree": "^2.3.1",
@@ -13346,9 +13346,9 @@
           }
         },
         "typescript": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-          "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+          "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
           "dev": true,
           "peer": true
         }
@@ -13590,17 +13590,17 @@
           }
         },
         "svelte": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-          "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+          "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
           "dev": true,
           "peer": true,
           "requires": {
             "@ampproject/remapping": "^2.2.1",
             "@jridgewell/sourcemap-codec": "^1.4.15",
             "@jridgewell/trace-mapping": "^0.3.18",
-            "acorn": "^8.8.2",
-            "aria-query": "^5.2.1",
+            "acorn": "^8.9.0",
+            "aria-query": "^5.3.0",
             "axobject-query": "^3.2.1",
             "code-red": "^1.0.3",
             "css-tree": "^2.3.1",
@@ -13622,9 +13622,9 @@
           }
         },
         "typescript": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-          "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+          "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
           "dev": true,
           "peer": true
         }
@@ -13874,17 +13874,17 @@
           }
         },
         "svelte": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-          "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+          "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
           "dev": true,
           "peer": true,
           "requires": {
             "@ampproject/remapping": "^2.2.1",
             "@jridgewell/sourcemap-codec": "^1.4.15",
             "@jridgewell/trace-mapping": "^0.3.18",
-            "acorn": "^8.8.2",
-            "aria-query": "^5.2.1",
+            "acorn": "^8.9.0",
+            "aria-query": "^5.3.0",
             "axobject-query": "^3.2.1",
             "code-red": "^1.0.3",
             "css-tree": "^2.3.1",
@@ -13906,9 +13906,9 @@
           }
         },
         "typescript": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-          "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+          "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
           "dev": true,
           "peer": true
         }
@@ -14094,17 +14094,17 @@
           }
         },
         "svelte": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-          "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+          "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
           "dev": true,
           "peer": true,
           "requires": {
             "@ampproject/remapping": "^2.2.1",
             "@jridgewell/sourcemap-codec": "^1.4.15",
             "@jridgewell/trace-mapping": "^0.3.18",
-            "acorn": "^8.8.2",
-            "aria-query": "^5.2.1",
+            "acorn": "^8.9.0",
+            "aria-query": "^5.3.0",
             "axobject-query": "^3.2.1",
             "code-red": "^1.0.3",
             "css-tree": "^2.3.1",
@@ -14126,9 +14126,9 @@
           }
         },
         "typescript": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-          "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+          "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
           "dev": true,
           "peer": true
         }
@@ -14534,17 +14534,17 @@
           }
         },
         "svelte": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-          "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+          "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
           "dev": true,
           "peer": true,
           "requires": {
             "@ampproject/remapping": "^2.2.1",
             "@jridgewell/sourcemap-codec": "^1.4.15",
             "@jridgewell/trace-mapping": "^0.3.18",
-            "acorn": "^8.8.2",
-            "aria-query": "^5.2.1",
+            "acorn": "^8.9.0",
+            "aria-query": "^5.3.0",
             "axobject-query": "^3.2.1",
             "code-red": "^1.0.3",
             "css-tree": "^2.3.1",
@@ -14566,9 +14566,9 @@
           }
         },
         "typescript": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-          "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+          "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
           "dev": true,
           "peer": true
         }
@@ -14839,17 +14839,17 @@
           }
         },
         "svelte": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-          "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+          "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
           "dev": true,
           "peer": true,
           "requires": {
             "@ampproject/remapping": "^2.2.1",
             "@jridgewell/sourcemap-codec": "^1.4.15",
             "@jridgewell/trace-mapping": "^0.3.18",
-            "acorn": "^8.8.2",
-            "aria-query": "^5.2.1",
+            "acorn": "^8.9.0",
+            "aria-query": "^5.3.0",
             "axobject-query": "^3.2.1",
             "code-red": "^1.0.3",
             "css-tree": "^2.3.1",
@@ -14871,9 +14871,9 @@
           }
         },
         "typescript": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-          "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+          "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
           "dev": true,
           "peer": true
         }
@@ -15189,17 +15189,17 @@
           }
         },
         "svelte": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-          "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+          "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
           "dev": true,
           "peer": true,
           "requires": {
             "@ampproject/remapping": "^2.2.1",
             "@jridgewell/sourcemap-codec": "^1.4.15",
             "@jridgewell/trace-mapping": "^0.3.18",
-            "acorn": "^8.8.2",
-            "aria-query": "^5.2.1",
+            "acorn": "^8.9.0",
+            "aria-query": "^5.3.0",
             "axobject-query": "^3.2.1",
             "code-red": "^1.0.3",
             "css-tree": "^2.3.1",
@@ -15221,9 +15221,9 @@
           }
         },
         "typescript": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-          "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+          "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
           "dev": true,
           "peer": true
         }
@@ -15318,17 +15318,17 @@
           }
         },
         "svelte": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.0.tgz",
-          "integrity": "sha512-+yCYu3AEUu9n91dnQNGIbnVp8EmNQtuF/YImW4+FTXRHard7NMo+yTsWzggPAbj3fUEJ1FBJLkql/jkp6YB5pg==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.0.1.tgz",
+          "integrity": "sha512-7n2u7A5cu8xCY6MBiXh/Mg6Lh3+Mw2qXlTDBYhzvCvmSM4L4gc4MVo540UtGcjqBiA48E1VDW+EUpBr7iuBlPg==",
           "dev": true,
           "peer": true,
           "requires": {
             "@ampproject/remapping": "^2.2.1",
             "@jridgewell/sourcemap-codec": "^1.4.15",
             "@jridgewell/trace-mapping": "^0.3.18",
-            "acorn": "^8.8.2",
-            "aria-query": "^5.2.1",
+            "acorn": "^8.9.0",
+            "aria-query": "^5.3.0",
             "axobject-query": "^3.2.1",
             "code-red": "^1.0.3",
             "css-tree": "^2.3.1",
@@ -15350,9 +15350,9 @@
           }
         },
         "typescript": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-          "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+          "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
           "dev": true,
           "peer": true
         }
@@ -15484,9 +15484,9 @@
       "peer": true
     },
     "aria-query": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.2.1.tgz",
-      "integrity": "sha512-7uFg4b+lETFgdaJyETnILsXgnnzVnkHcgRbwbPwevm5x/LmUlt3MjczMRe1zg824iBgXZNRPTBftNYyRSKLp2g==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "peer": true,
       "requires": {

--- a/src/routers/Search/dashboard/src/App.svelte
+++ b/src/routers/Search/dashboard/src/App.svelte
@@ -601,11 +601,11 @@
     height: 100%;
   }
 
-  * :global(.app-content) {
-    flex: auto;
+  * :global(.app-content),
+  * :global(.mdc-drawer-app-content) {
+    flex: 1;
     overflow: auto;
-    position: relative;
-    flex-grow: 1;
+    display: flex;
   }
 
   :global(.log.info) {

--- a/src/routers/Search/dashboard/src/App.svelte
+++ b/src/routers/Search/dashboard/src/App.svelte
@@ -476,76 +476,79 @@
   </Actions>
 </Dialog>
 <!-- Main app -->
-<AppHeader
-  {title}
-  on:createArtifact={() => (creatingArtifact = true)}
-  on:openEditor={onOpenInEditor} />
-{#if isLoading}
-  <LinearProgress indeterminate />
-{/if}
-<SvelteToast options={{ classes: ["log"] }} />
-<!-- TODO: make the drawer collapsible? -->
-<div class="drawer-container">
-  <Drawer style="width: 360px">
-    <Content>
-      <Textfield label="Search..." bind:value={searchQuery} />
-      <span class="filter-header">Advanced Filters</span>
-      <TaxonomyFilter
-        trees={vocabularies}
-        tags={itemTags}
-        on:change={(event) =>
-          (filterTags = event.detail.filterTags.map(fromDict))}
-      />
-    </Content>
-  </Drawer>
-  <AppContent>
-    <main style="display: inline-block; vertical-align: top">
-      <!-- Artifact list -->
-      {#if items.length}
-        <List twoLine avatarList>
-          {#each items as item (item.hash)}
-            <Item
-              selected={item === selectedArtifactSet}
-              on:SMUI:action={() => onItemClicked(item)}
-            >
-              <Text>
-                <PrimaryText>{item.displayName}</PrimaryText>
-                <SecondaryText />
-              </Text>
-              {#each item.taxonomyTags as tag}
-                <!--
-                                                          <Chip chip={tag.id}>
-                  {#if tag.type === 'EnumField'}
-              <Text>{tag.name}</Text>
-                                          {:else if tag.value}
-              <Text>{tag.name}: {tag.value}</Text>
-                  {:else}
-              <Text>{tag.name}</Text>
-                  {/if}
-                                                          </Chip>
-                -->
-              {/each}
-            </Item>
-          {/each}
-        </List>
-      {:else if !isLoading}
-        <Paper variant="unelevated" class="empty">
-          <PaperContent>
-            <p>No results found</p>
-          </PaperContent>
-        </Paper>
+<main id="app">
+  <AppHeader
+    {title}
+    on:createArtifact={() => (creatingArtifact = true)}
+    on:openEditor={onOpenInEditor}
+  />
+  {#if isLoading}
+    <LinearProgress indeterminate />
+  {/if}
+  <SvelteToast options={{ classes: ["log"] }} />
+  <!-- TODO: make the drawer collapsible? -->
+  <div class="drawer-container">
+    <Drawer style="width: 360px">
+      <Content>
+        <Textfield label="Search..." bind:value={searchQuery} />
+        <span class="filter-header">Advanced Filters</span>
+        <TaxonomyFilter
+          trees={vocabularies}
+          tags={itemTags}
+          on:change={(event) =>
+            (filterTags = event.detail.filterTags.map(fromDict))}
+        />
+      </Content>
+    </Drawer>
+    <AppContent>
+      <main style="display: inline-block; vertical-align: top">
+        <!-- Artifact list -->
+        {#if items.length}
+          <List twoLine avatarList>
+            {#each items as item (item.hash)}
+              <Item
+                selected={item === selectedArtifactSet}
+                on:SMUI:action={() => onItemClicked(item)}
+              >
+                <Text>
+                  <PrimaryText>{item.displayName}</PrimaryText>
+                  <SecondaryText />
+                </Text>
+                {#each item.taxonomyTags as tag}
+                  <!--
+                                                            <Chip chip={tag.id}>
+                    {#if tag.type === 'EnumField'}
+                <Text>{tag.name}</Text>
+                                            {:else if tag.value}
+                <Text>{tag.name}: {tag.value}</Text>
+                    {:else}
+                <Text>{tag.name}</Text>
+                    {/if}
+                                                            </Chip>
+                  -->
+                {/each}
+              </Item>
+            {/each}
+          </List>
+        {:else if !isLoading}
+          <Paper variant="unelevated" class="empty">
+            <PaperContent>
+              <p>No results found</p>
+            </PaperContent>
+          </Paper>
+        {/if}
+      </main>
+      {#if selectedArtifactSet}
+        <ArtifactSetViewer
+          bind:artifactSet={selectedArtifactSet}
+          bind:contentType
+          on:download={(event) => onDownload(event.detail)}
+          on:upload={(event) => (appendItem = event.detail.artifactSet)}
+        />
       {/if}
-    </main>
-    {#if selectedArtifactSet}
-      <ArtifactSetViewer
-        bind:artifactSet={selectedArtifactSet}
-        bind:contentType
-        on:download={(event) => onDownload(event.detail)}
-        on:upload={(event) => (appendItem = event.detail.artifactSet)}
-      />
-    {/if}
-  </AppContent>
-</div>
+    </AppContent>
+  </div>
+</main>
 
 <!-- Material Icons -->
 <link
@@ -571,6 +574,12 @@
     }
   }
 
+  main#app {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
   .filter-header {
     display: block;
     padding-top: 10px;
@@ -579,8 +588,10 @@
   /* FIXME: this is an annoying hack to get the placement/size right*/
   .drawer-container {
     position: relative;
+    padding: 0 8px;
+    flex: 1;
+    /* min-height: 0; */
     display: flex;
-    height: 100%;
   }
 
   * :global(.app-content),

--- a/src/routers/Search/dashboard/src/App.svelte
+++ b/src/routers/Search/dashboard/src/App.svelte
@@ -590,7 +590,7 @@
     position: relative;
     padding: 0 8px;
     flex: 1;
-    /* min-height: 0; */
+    min-height: 0;
     display: flex;
   }
 
@@ -599,6 +599,11 @@
     flex: 1;
     overflow: auto;
     display: flex;
+  }
+
+  :global(.mdc-drawer-app-content) > main {
+    min-height: 0;
+    overflow-y: scroll;
   }
 
   :global(.log.info) {

--- a/src/routers/Search/dashboard/src/App.svelte
+++ b/src/routers/Search/dashboard/src/App.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { setContext } from "svelte";
   import { FilterTag, LeanTag, fromDict } from "./tags";
-  import TopAppBar, { Row, Section, Title } from "@smui/top-app-bar";
   import { filterMap } from "./Utils";
   import {
     getLatestArtifact,
@@ -10,7 +9,6 @@
     readFile,
   } from "./Utils";
   import Textfield from "@smui/textfield";
-  import IconButton from "@smui/icon-button";
   import { SvelteToast, toast } from "@zerodevx/svelte-toast";
   /*import Chip from "@smui/chips";*/
   import List, {
@@ -33,6 +31,7 @@
   import Button, { Label } from "@smui/button";
   import Paper, { Content as PaperContent } from "@smui/paper";
   import {
+    AppHeader,
     AppendArtifactDialog,
     ArtifactSetViewer,
     TaxonomyFilter,
@@ -477,27 +476,10 @@
   </Actions>
 </Dialog>
 <!-- Main app -->
-<TopAppBar variant="static">
-  <Row>
-    <Section>
-      <Title>{title}</Title>
-    </Section>
-    <Section align="end" toolbar>
-      <IconButton
-        class="material-icons"
-        aria-label="Upload dataset"
-        ripple={false}
-        on:click={() => (creatingArtifact = true)}>file_upload</IconButton
-      >
-      <IconButton
-        class="material-icons"
-        aria-label="Edit taxonomy"
-        ripple={false}
-        on:click={onOpenInEditor}>open_in_new</IconButton
-      >
-    </Section>
-  </Row>
-</TopAppBar>
+<AppHeader
+  {title}
+  on:createArtifact={() => (creatingArtifact = true)}
+  on:openEditor={onOpenInEditor} />
 {#if isLoading}
   <LinearProgress indeterminate />
 {/if}

--- a/src/routers/Search/dashboard/src/app.css
+++ b/src/routers/Search/dashboard/src/app.css
@@ -1,0 +1,3 @@
+body {
+  padding: 0;
+}

--- a/src/routers/Search/dashboard/src/app.css
+++ b/src/routers/Search/dashboard/src/app.css
@@ -1,3 +1,4 @@
 body {
   padding: 0;
+  max-height: 100vh;
 }

--- a/src/routers/Search/dashboard/src/components/AppHeader.svelte
+++ b/src/routers/Search/dashboard/src/components/AppHeader.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import TopAppBar, { Row, Section, Title } from "@smui/top-app-bar";
+  import IconButton from "@smui/icon-button";
+
+  export let title: string | null = null;
+
+  const dispatch = createEventDispatcher();
+
+  function createArtifact() {
+    dispatch('createArtifact');
+  }
+
+  function openEditor() {
+    dispatch('openEditor');
+  }
+</script>
+
+<TopAppBar variant="static">
+  <Row>
+    <Section>
+      {#if title}
+        <Title>{title}</Title>
+      {/if}
+    </Section>
+
+    <Section align="end" toolbar>
+      <IconButton
+        class="material-icons"
+        aria-label="Upload dataset"
+        ripple={false}
+        on:click={createArtifact}>file_upload
+      </IconButton>
+      <IconButton
+        class="material-icons"
+        aria-label="Edit taxonomy"
+        ripple={false}
+        on:click={openEditor}>open_in_new
+      </IconButton>
+    </Section>
+  </Row>
+</TopAppBar>

--- a/src/routers/Search/dashboard/src/components/ArtifactSetViewer.svelte
+++ b/src/routers/Search/dashboard/src/components/ArtifactSetViewer.svelte
@@ -180,12 +180,24 @@
 
 <style>
   .card-container {
-    display: inline-block;
+    display: inline-flex;
     vertical-align: top;
   }
 
-  .sticky {
-    position: fixed;
-    top: 0;
+  .card-container > :global(.mdc-card) {
+    flex: 1;
+  }
+
+  .card-container > :global(.mdc-card .smui-card__content) {
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    flex: 0 1 auto;
+    min-height: 0;
+  }
+
+  .card-container > :global(.mdc-card .smui-card__content .mdc-deprecated-list) {
+    flex: 0 1 auto;
+    overflow-y: scroll;
   }
 </style>

--- a/src/routers/Search/dashboard/src/components/ArtifactSetViewer.svelte
+++ b/src/routers/Search/dashboard/src/components/ArtifactSetViewer.svelte
@@ -142,7 +142,7 @@
         </Menu>
       </h4>
       <!-- add show more button, select all -->
-      <List checkList>
+      <List checkList twoLine>
         <!-- TODO: check if they have permissions to append to it -->
         {#each shownArtifacts as artifact (artifact.id)}
           <Item>

--- a/src/routers/Search/dashboard/src/components/ArtifactSetViewer.svelte
+++ b/src/routers/Search/dashboard/src/components/ArtifactSetViewer.svelte
@@ -3,9 +3,7 @@
   import TagFormatter from "../Formatter";
   import Card, { Content, Actions } from "@smui/card";
   import Button, { Label } from "@smui/button";
-  import type { ButtonComponentDev } from "@smui/button";
   import Menu from "@smui/menu";
-  import type { MenuComponentDev } from "@smui/menu";
   import IconButton from "@smui/icon-button";
   import List, {
     Item,
@@ -23,7 +21,7 @@
   let numArtifacts = 10;
   let shownArtifacts = [];
   let selected = [];
-  let menu: MenuComponentDev;
+  let menu: Menu;
   const formatter = new TagFormatter();
 
   import { createEventDispatcher } from "svelte";

--- a/src/routers/Search/dashboard/src/components/ArtifactSetViewer.svelte
+++ b/src/routers/Search/dashboard/src/components/ArtifactSetViewer.svelte
@@ -94,31 +94,15 @@
     } as const;
     return date.toLocaleDateString("en-us", formatOpts);
   }
-
-  // Ensure the window always stays at the top of the screen
-  let scrollY;
-  let panel;
-  let panelOffset = 0;
-  $: {
-    if (panel) {
-      const parentRect = panel.offsetParent.getBoundingClientRect();
-      panelOffset = parentRect.top + panel.offsetTop;
-    }
-  }
 </script>
 
-<svelte:window bind:scrollY />
 {#if displayedTags}
   <DisplayTagsDialog
     bind:open={displayTags}
     displayName={displayedName}
     bind:taxonomyTags={displayedTags}/>
 {/if}
-<div
-  bind:this={panel}
-  class="card-container"
-  class:sticky={scrollY > panelOffset}
->
+<div class="card-container">
   <!-- TODO: add a header for the observation -->
   <!-- TODO: upload times -->
   <!-- Artifact list -->
@@ -137,8 +121,8 @@
           class="material-icons"
           style="vertical-align: middle; margin: 0; padding: 0;"
           on:click={() => menu.setOpen(true)}
-          title="Options">more_vert</IconButton
-        >
+          title="Options">more_vert
+        </IconButton>
         <Menu bind:this={menu} anchorCorner="BOTTOM_RIGHT">
           <List>
             <Item

--- a/src/routers/Search/dashboard/src/components/index.ts
+++ b/src/routers/Search/dashboard/src/components/index.ts
@@ -1,3 +1,4 @@
+export { default as AppHeader } from "./AppHeader.svelte";
 export { default as AppendArtifactDialog } from "./AppendArtifactDialog.svelte";
 export { default as ArtifactSetViewer } from "./ArtifactSetViewer.svelte";
 export { default as TaxonomyFilter } from "./TaxonomyFilter.svelte";

--- a/src/routers/Search/dashboard/src/main.ts
+++ b/src/routers/Search/dashboard/src/main.ts
@@ -1,10 +1,8 @@
+import "./app.css";
 import App from "./App.svelte";
 
 const app = new App({
   target: document.body,
-  props: {
-    name: "world",
-  },
 });
 
 export default app;


### PR DESCRIPTION
Fixes the "flicker" of the observations list when it extends past the bottom of the browser.

To do this, I removed the logic that binds to `scrollY` and instead makes the 3 different dashboard "panels" separately scrollable.

resolves #274 