### PR TITLE
Add notes.md to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ src/routers/Search/dashboard/src/Bearer.ts
 /test-results/
 /playwright-report/
 /playwright/.cache/
+notes.md


### PR DESCRIPTION
I often track my train of thought, etc, in a local notes.md file and
want to ensure it isn't accidently committed or included in the docker
image
