### PR TITLE
Pass repo ID instead of repo. Fix #419

### DIFF
--- a/src/routers/Insights/Insights.js
+++ b/src/routers/Insights/Insights.js
@@ -100,9 +100,9 @@ function initialize(middlewareOpts) {
         const allContents = (await Promise.all(
           storageAdapters
             .map(async (adapter) => {
-              const repos = await adapter.listRepos().catch(nop);
+              const repos = (await adapter.listRepos().catch(nop)) || [];
               const contents = await Promise.all(
-                repos.map((repo) => adapter.listArtifacts(repo)),
+                repos.map((repo) => adapter.listArtifacts(repo.id)),
               );
               return contents.flat();
             }),


### PR DESCRIPTION
Oddly, the mongo DB adapter seems to work when the repo is used in place of the repo ID...