### PR TITLE
Update svelte jsonschema form

### DIFF
--- a/src/routers/Insights/dashboard/package-lock.json
+++ b/src/routers/Insights/dashboard/package-lock.json
@@ -187,16 +187,6 @@
       "integrity": "sha512-vYY5EIxCPzEXEWL/vTjdHy4g92tv1ApUQCjPJsj9gEoXLNNVwJlwwgRZisuvgFBZ3zeLzQygrbehERSpYdmFZA==",
       "dev": true
     },
-    "node_modules/@json-schema-tools/validator": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/validator/-/validator-1.4.0.tgz",
-      "integrity": "sha512-0t/dBRszJEznq96EBabltiogsWxY/O2ECa9oM85a2By6q2uARJeztymdM9gmPFi0AhxlpOIi/byZcR+4zSvIMw==",
-      "dev": true,
-      "dependencies": {
-        "@json-schema-tools/traverse": "^1.10.0",
-        "jsonpath": "^1.1.1"
-      }
-    },
     "node_modules/@material/animation": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/@material/animation/-/animation-13.0.0.tgz",
@@ -2678,15 +2668,15 @@
       }
     },
     "node_modules/@smui/checkbox": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/checkbox/-/checkbox-7.0.0-beta.9.tgz",
-      "integrity": "sha512-LPnYywI3m4kEgskLDs48UcWz5ulIGqZ/l/tzk5/6vibq8NGLYTW6k6v5rEYx9EfoNRMN+K4QNL2AOtIL25v+CQ==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/checkbox/-/checkbox-7.0.0-beta.15.tgz",
+      "integrity": "sha512-lDRHkec8qCNz8SAdV8G1XoFLdj340OVK0KoEszo/KTu+eIfIfkiIKrvZj5TEb8ohGV1j0QuaOivlhnP+CNDERA==",
       "dev": true,
       "dependencies": {
         "@material/checkbox": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "@smui/ripple": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/ripple": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/checkbox/node_modules/@material/animation": {
@@ -2801,31 +2791,31 @@
       }
     },
     "node_modules/@smui/checkbox/node_modules/@smui/common": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.9.tgz",
-      "integrity": "sha512-Wf63UfvaB8hDSzxkoqCUpFiJffQixmyKW+mWVE5ZUQ94Vwg0gZWGbNMEBrwrtI4tHomMQ95VVNdps/KsaXlStw==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
+      "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
       "dev": true,
       "dependencies": {
         "@material/dom": "^14.0.0",
-        "svelte2tsx": "^0.6.15"
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/checkbox/node_modules/@smui/ripple": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.9.tgz",
-      "integrity": "sha512-N21ONk6cFMAkKfLjPDMyEKNvcAzklxpJ/TXIWQBUJxRQJZcjhPLLq9y5RpqVF+0DiIFHXm/hQJv98psPtJqHIw==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.15.tgz",
+      "integrity": "sha512-l0c94p60gxbsClH0KzA2meJ2IGHc7ZUMyWqODkLNz7ziUYxk3VZvWf/Y7Ca+64IJj0keCGPMpFauFaJO8h3Gtw==",
       "dev": true,
       "dependencies": {
         "@material/dom": "^14.0.0",
         "@material/ripple": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/checkbox/node_modules/svelte2tsx": {
-      "version": "0.6.16",
-      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.16.tgz",
-      "integrity": "sha512-AX2iYEvQdd4tq5BokRdOOA0N/nD37ZnhXAomrAG9EEGl2cjkvoQUwe1Aluo6FSzA684WJjhxW+1ZXmveCmvDrA==",
+      "version": "0.6.23",
+      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.23.tgz",
+      "integrity": "sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==",
       "dev": true,
       "dependencies": {
         "dedent-js": "^1.0.1",
@@ -3399,16 +3389,16 @@
       }
     },
     "node_modules/@smui/form-field": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/form-field/-/form-field-7.0.0-beta.9.tgz",
-      "integrity": "sha512-OBXImDdVm9cbHZYFIA+d5pw2MqhjJ0poBOzcXOxenzIlWUOC0ettNhvES4bjmnM1SjROi5SpSZ7DDJxkvdfxlQ==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/form-field/-/form-field-7.0.0-beta.15.tgz",
+      "integrity": "sha512-Ou2Og5pVkktrhPW0c+eA+A6O9WJrpqmOh+ZqekQfixiJRmP13645NRk3qbA0NUoIBb6m+9wJ2KbEoZ0yrHWnaw==",
       "dev": true,
       "dependencies": {
         "@material/feature-targeting": "^14.0.0",
         "@material/form-field": "^14.0.0",
         "@material/rtl": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/form-field/node_modules/@material/dom": {
@@ -3451,19 +3441,19 @@
       }
     },
     "node_modules/@smui/form-field/node_modules/@smui/common": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.9.tgz",
-      "integrity": "sha512-Wf63UfvaB8hDSzxkoqCUpFiJffQixmyKW+mWVE5ZUQ94Vwg0gZWGbNMEBrwrtI4tHomMQ95VVNdps/KsaXlStw==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
+      "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
       "dev": true,
       "dependencies": {
         "@material/dom": "^14.0.0",
-        "svelte2tsx": "^0.6.15"
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/form-field/node_modules/svelte2tsx": {
-      "version": "0.6.16",
-      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.16.tgz",
-      "integrity": "sha512-AX2iYEvQdd4tq5BokRdOOA0N/nD37ZnhXAomrAG9EEGl2cjkvoQUwe1Aluo6FSzA684WJjhxW+1ZXmveCmvDrA==",
+      "version": "0.6.23",
+      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.23.tgz",
+      "integrity": "sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==",
       "dev": true,
       "dependencies": {
         "dedent-js": "^1.0.1",
@@ -3489,16 +3479,16 @@
       }
     },
     "node_modules/@smui/icon-button": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/icon-button/-/icon-button-7.0.0-beta.9.tgz",
-      "integrity": "sha512-F1QmslrdIq+plkKnIvN2cyVPFish7lhw7cYzxpWzhOXbjF1Bay0mmyuHSYjiZ3//LL1CcFOnZJ/QMT8dKqfgYg==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/icon-button/-/icon-button-7.0.0-beta.15.tgz",
+      "integrity": "sha512-Hvvv9w6hDCDOrSgxlcsXrCLOE8VJeTJ5Tu1n+FBqvIfetaF7ATXDwXx+raEznJ4kZK6CyoQTzMIr2rz4hxGiMA==",
       "dev": true,
       "dependencies": {
         "@material/density": "^14.0.0",
         "@material/icon-button": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "@smui/ripple": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/ripple": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/icon-button/node_modules/@material/animation": {
@@ -3628,31 +3618,31 @@
       }
     },
     "node_modules/@smui/icon-button/node_modules/@smui/common": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.9.tgz",
-      "integrity": "sha512-Wf63UfvaB8hDSzxkoqCUpFiJffQixmyKW+mWVE5ZUQ94Vwg0gZWGbNMEBrwrtI4tHomMQ95VVNdps/KsaXlStw==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
+      "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
       "dev": true,
       "dependencies": {
         "@material/dom": "^14.0.0",
-        "svelte2tsx": "^0.6.15"
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/icon-button/node_modules/@smui/ripple": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.9.tgz",
-      "integrity": "sha512-N21ONk6cFMAkKfLjPDMyEKNvcAzklxpJ/TXIWQBUJxRQJZcjhPLLq9y5RpqVF+0DiIFHXm/hQJv98psPtJqHIw==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.15.tgz",
+      "integrity": "sha512-l0c94p60gxbsClH0KzA2meJ2IGHc7ZUMyWqODkLNz7ziUYxk3VZvWf/Y7Ca+64IJj0keCGPMpFauFaJO8h3Gtw==",
       "dev": true,
       "dependencies": {
         "@material/dom": "^14.0.0",
         "@material/ripple": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/icon-button/node_modules/svelte2tsx": {
-      "version": "0.6.16",
-      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.16.tgz",
-      "integrity": "sha512-AX2iYEvQdd4tq5BokRdOOA0N/nD37ZnhXAomrAG9EEGl2cjkvoQUwe1Aluo6FSzA684WJjhxW+1ZXmveCmvDrA==",
+      "version": "0.6.23",
+      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.23.tgz",
+      "integrity": "sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==",
       "dev": true,
       "dependencies": {
         "dedent-js": "^1.0.1",
@@ -3718,17 +3708,17 @@
       }
     },
     "node_modules/@smui/list": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/list/-/list-7.0.0-beta.9.tgz",
-      "integrity": "sha512-nSpiFK5kd+yCDrG6dJR5+flYaPiI77zeWMJzmE3XGvqXrQULjTSatCIRmgFjTJYwsDKcWb8xT7Omg7T/H+IoqQ==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/list/-/list-7.0.0-beta.15.tgz",
+      "integrity": "sha512-5NeAgVLjcaJo0Mr4IXB1QaAb3UGBtNWJqHNwVXfPpADIb3vKLNGpKrXv5koKqCLGEapkEjQ2PqixURaB/5O2eg==",
       "dev": true,
       "dependencies": {
         "@material/dom": "^14.0.0",
         "@material/feature-targeting": "^14.0.0",
         "@material/list": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "@smui/ripple": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/ripple": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/list/node_modules/@material/animation": {
@@ -3854,31 +3844,31 @@
       }
     },
     "node_modules/@smui/list/node_modules/@smui/common": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.9.tgz",
-      "integrity": "sha512-Wf63UfvaB8hDSzxkoqCUpFiJffQixmyKW+mWVE5ZUQ94Vwg0gZWGbNMEBrwrtI4tHomMQ95VVNdps/KsaXlStw==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
+      "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
       "dev": true,
       "dependencies": {
         "@material/dom": "^14.0.0",
-        "svelte2tsx": "^0.6.15"
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/list/node_modules/@smui/ripple": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.9.tgz",
-      "integrity": "sha512-N21ONk6cFMAkKfLjPDMyEKNvcAzklxpJ/TXIWQBUJxRQJZcjhPLLq9y5RpqVF+0DiIFHXm/hQJv98psPtJqHIw==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.15.tgz",
+      "integrity": "sha512-l0c94p60gxbsClH0KzA2meJ2IGHc7ZUMyWqODkLNz7ziUYxk3VZvWf/Y7Ca+64IJj0keCGPMpFauFaJO8h3Gtw==",
       "dev": true,
       "dependencies": {
         "@material/dom": "^14.0.0",
         "@material/ripple": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/list/node_modules/svelte2tsx": {
-      "version": "0.6.16",
-      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.16.tgz",
-      "integrity": "sha512-AX2iYEvQdd4tq5BokRdOOA0N/nD37ZnhXAomrAG9EEGl2cjkvoQUwe1Aluo6FSzA684WJjhxW+1ZXmveCmvDrA==",
+      "version": "0.6.23",
+      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.23.tgz",
+      "integrity": "sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==",
       "dev": true,
       "dependencies": {
         "dedent-js": "^1.0.1",
@@ -3904,17 +3894,17 @@
       }
     },
     "node_modules/@smui/menu": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/menu/-/menu-7.0.0-beta.9.tgz",
-      "integrity": "sha512-GpfDZUqSywcNrVzWmHs63uDJiVneK+WuGqC9D6l58Uj5TsPT5fr4UGFfuWAl6685pDjD3eCwEmyFdQKi3DPXfA==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/menu/-/menu-7.0.0-beta.15.tgz",
+      "integrity": "sha512-hvw8iRuWvo1Lc1O6MaAtO99vIUQMlheK5vvG046WZlzwuiZMulBvtipc74nhM69BdrTTDAob69xsZXHih3LHVw==",
       "dev": true,
       "dependencies": {
         "@material/dom": "^14.0.0",
         "@material/menu": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "@smui/list": "^7.0.0-beta.9",
-        "@smui/menu-surface": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/list": "^7.0.0-beta.15",
+        "@smui/menu-surface": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/menu-surface": {
@@ -4099,31 +4089,31 @@
       }
     },
     "node_modules/@smui/menu/node_modules/@smui/common": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.9.tgz",
-      "integrity": "sha512-Wf63UfvaB8hDSzxkoqCUpFiJffQixmyKW+mWVE5ZUQ94Vwg0gZWGbNMEBrwrtI4tHomMQ95VVNdps/KsaXlStw==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
+      "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
       "dev": true,
       "dependencies": {
         "@material/dom": "^14.0.0",
-        "svelte2tsx": "^0.6.15"
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/menu/node_modules/@smui/menu-surface": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/menu-surface/-/menu-surface-7.0.0-beta.9.tgz",
-      "integrity": "sha512-xmSyvNCVYDGYrZdZw1TXKmbX3rZYpubxiGcPXnHEElR2zljAwg9LsHKD8ZnpzJJZrpxTpO3xCrj0ybB0yYxqLA==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/menu-surface/-/menu-surface-7.0.0-beta.15.tgz",
+      "integrity": "sha512-fpBJD1+gBUdegMM0qoZg9Fu5j/9TfAtxDBRBqAoHWKY7sW9uqbHhV1lwkVLWs7V+PKXWamTIX37//EHSIVw0TQ==",
       "dev": true,
       "dependencies": {
         "@material/animation": "^14.0.0",
         "@material/menu-surface": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/menu/node_modules/svelte2tsx": {
-      "version": "0.6.16",
-      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.16.tgz",
-      "integrity": "sha512-AX2iYEvQdd4tq5BokRdOOA0N/nD37ZnhXAomrAG9EEGl2cjkvoQUwe1Aluo6FSzA684WJjhxW+1ZXmveCmvDrA==",
+      "version": "0.6.23",
+      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.23.tgz",
+      "integrity": "sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==",
       "dev": true,
       "dependencies": {
         "dedent-js": "^1.0.1",
@@ -4330,9 +4320,9 @@
       }
     },
     "node_modules/@smui/select": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/select/-/select-7.0.0-beta.9.tgz",
-      "integrity": "sha512-LB7KiOQT92j6IJAuwHIlaF7G3beLPOUqPsNB/FFN8JKpQSnjx7w7PjLvcgSLlfxkxX38XfNE1dwH8KUp4JKOhA==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/select/-/select-7.0.0-beta.15.tgz",
+      "integrity": "sha512-quYIEaFDt5aXOj3ZnV5axDDWkrkASAWcRzd/P1PQ2bCAQNaaichaUOV+2QGbYVD8G+UiRBYy8fgJMpIE9s9KUg==",
       "dev": true,
       "dependencies": {
         "@material/feature-targeting": "^14.0.0",
@@ -4340,15 +4330,15 @@
         "@material/rtl": "^14.0.0",
         "@material/select": "^14.0.0",
         "@material/theme": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "@smui/floating-label": "^7.0.0-beta.9",
-        "@smui/line-ripple": "^7.0.0-beta.9",
-        "@smui/list": "^7.0.0-beta.9",
-        "@smui/menu": "^7.0.0-beta.9",
-        "@smui/menu-surface": "^7.0.0-beta.9",
-        "@smui/notched-outline": "^7.0.0-beta.9",
-        "@smui/ripple": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/floating-label": "^7.0.0-beta.15",
+        "@smui/line-ripple": "^7.0.0-beta.15",
+        "@smui/list": "^7.0.0-beta.15",
+        "@smui/menu": "^7.0.0-beta.15",
+        "@smui/menu-surface": "^7.0.0-beta.15",
+        "@smui/notched-outline": "^7.0.0-beta.15",
+        "@smui/ripple": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/select/node_modules/@material/animation": {
@@ -4602,77 +4592,77 @@
       }
     },
     "node_modules/@smui/select/node_modules/@smui/common": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.9.tgz",
-      "integrity": "sha512-Wf63UfvaB8hDSzxkoqCUpFiJffQixmyKW+mWVE5ZUQ94Vwg0gZWGbNMEBrwrtI4tHomMQ95VVNdps/KsaXlStw==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
+      "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
       "dev": true,
       "dependencies": {
         "@material/dom": "^14.0.0",
-        "svelte2tsx": "^0.6.15"
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/select/node_modules/@smui/floating-label": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/floating-label/-/floating-label-7.0.0-beta.9.tgz",
-      "integrity": "sha512-Il3ztKWBjWX3yz7pCZq9C4DpUzRZ4ewKMA6YQ5uqsWRn/crVHPCk5irSVc3chZ7jGHZ6ZvbUYn7qGTv8OlVobg==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/floating-label/-/floating-label-7.0.0-beta.15.tgz",
+      "integrity": "sha512-KRjZjO8AGE5uKHewmn05vyAxIi6XOGo8a4jn8b0+dIJcYxaPpmtacH4PeQHw4vOR88cX/0DqqxSz6+Fkrt+SIA==",
       "dev": true,
       "dependencies": {
         "@material/floating-label": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/select/node_modules/@smui/line-ripple": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/line-ripple/-/line-ripple-7.0.0-beta.9.tgz",
-      "integrity": "sha512-GuWd+mVY1BrLi9Y0/r+5G/EzQXiGmDGxqRTSxA4Ufa6zEhGZ8bk7tHT/WvGZL/xq87MTvJ3PWOYbLbNN3gi2mg==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/line-ripple/-/line-ripple-7.0.0-beta.15.tgz",
+      "integrity": "sha512-tfdEybgQlLiotELlWknLzb5l6pT47uGfMGYzLs5AVf74CU/zAhp8NiicHUUmI95qY5P2z2xHYYpdLTs1wZ5c9A==",
       "dev": true,
       "dependencies": {
         "@material/line-ripple": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/select/node_modules/@smui/menu-surface": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/menu-surface/-/menu-surface-7.0.0-beta.9.tgz",
-      "integrity": "sha512-xmSyvNCVYDGYrZdZw1TXKmbX3rZYpubxiGcPXnHEElR2zljAwg9LsHKD8ZnpzJJZrpxTpO3xCrj0ybB0yYxqLA==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/menu-surface/-/menu-surface-7.0.0-beta.15.tgz",
+      "integrity": "sha512-fpBJD1+gBUdegMM0qoZg9Fu5j/9TfAtxDBRBqAoHWKY7sW9uqbHhV1lwkVLWs7V+PKXWamTIX37//EHSIVw0TQ==",
       "dev": true,
       "dependencies": {
         "@material/animation": "^14.0.0",
         "@material/menu-surface": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/select/node_modules/@smui/notched-outline": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/notched-outline/-/notched-outline-7.0.0-beta.9.tgz",
-      "integrity": "sha512-oZ8ah/9sX+QiTyJwXhrqBkrpfjxwv53zOvyZbs6bVGFi2dp/HBzGXHuoUKgfWHtE8smC6Bd675BDpig8XN86PQ==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/notched-outline/-/notched-outline-7.0.0-beta.15.tgz",
+      "integrity": "sha512-9oVSIYmb1/GcCFYm1M0xVy4J5/A2Ysa4H6gm3RIL9/ke3F9EmmALmCs1lmtGu4Vwyo0ES5KroW2Tly2SzMfB2g==",
       "dev": true,
       "dependencies": {
         "@material/notched-outline": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "@smui/floating-label": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/floating-label": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/select/node_modules/@smui/ripple": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.9.tgz",
-      "integrity": "sha512-N21ONk6cFMAkKfLjPDMyEKNvcAzklxpJ/TXIWQBUJxRQJZcjhPLLq9y5RpqVF+0DiIFHXm/hQJv98psPtJqHIw==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.15.tgz",
+      "integrity": "sha512-l0c94p60gxbsClH0KzA2meJ2IGHc7ZUMyWqODkLNz7ziUYxk3VZvWf/Y7Ca+64IJj0keCGPMpFauFaJO8h3Gtw==",
       "dev": true,
       "dependencies": {
         "@material/dom": "^14.0.0",
         "@material/ripple": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/select/node_modules/svelte2tsx": {
-      "version": "0.6.16",
-      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.16.tgz",
-      "integrity": "sha512-AX2iYEvQdd4tq5BokRdOOA0N/nD37ZnhXAomrAG9EEGl2cjkvoQUwe1Aluo6FSzA684WJjhxW+1ZXmveCmvDrA==",
+      "version": "0.6.23",
+      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.23.tgz",
+      "integrity": "sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==",
       "dev": true,
       "dependencies": {
         "dedent-js": "^1.0.1",
@@ -5011,9 +5001,9 @@
       }
     },
     "node_modules/@smui/textfield": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/textfield/-/textfield-7.0.0-beta.9.tgz",
-      "integrity": "sha512-H/fXDjvg9QtOwAfzsbesOOre20dTBKRqWyNaWL4riIg6paDtDV9tdgQuugxwC+h/8dT3n8j69NidRshxmNuPQA==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/textfield/-/textfield-7.0.0-beta.15.tgz",
+      "integrity": "sha512-98lGaVJRH3K5aXVUAa8o/8rHRQ/Vwu9q6phupSrPW4BEmEEEezb/fzKExTOgm0c241dy4nDRLkdH9IdtObTA8w==",
       "dev": true,
       "dependencies": {
         "@material/dom": "^14.0.0",
@@ -5021,12 +5011,12 @@
         "@material/ripple": "^14.0.0",
         "@material/rtl": "^14.0.0",
         "@material/textfield": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "@smui/floating-label": "^7.0.0-beta.9",
-        "@smui/line-ripple": "^7.0.0-beta.9",
-        "@smui/notched-outline": "^7.0.0-beta.9",
-        "@smui/ripple": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/floating-label": "^7.0.0-beta.15",
+        "@smui/line-ripple": "^7.0.0-beta.15",
+        "@smui/notched-outline": "^7.0.0-beta.15",
+        "@smui/ripple": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/textfield/node_modules/@material/animation": {
@@ -5169,65 +5159,65 @@
       }
     },
     "node_modules/@smui/textfield/node_modules/@smui/common": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.9.tgz",
-      "integrity": "sha512-Wf63UfvaB8hDSzxkoqCUpFiJffQixmyKW+mWVE5ZUQ94Vwg0gZWGbNMEBrwrtI4tHomMQ95VVNdps/KsaXlStw==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
+      "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
       "dev": true,
       "dependencies": {
         "@material/dom": "^14.0.0",
-        "svelte2tsx": "^0.6.15"
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/textfield/node_modules/@smui/floating-label": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/floating-label/-/floating-label-7.0.0-beta.9.tgz",
-      "integrity": "sha512-Il3ztKWBjWX3yz7pCZq9C4DpUzRZ4ewKMA6YQ5uqsWRn/crVHPCk5irSVc3chZ7jGHZ6ZvbUYn7qGTv8OlVobg==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/floating-label/-/floating-label-7.0.0-beta.15.tgz",
+      "integrity": "sha512-KRjZjO8AGE5uKHewmn05vyAxIi6XOGo8a4jn8b0+dIJcYxaPpmtacH4PeQHw4vOR88cX/0DqqxSz6+Fkrt+SIA==",
       "dev": true,
       "dependencies": {
         "@material/floating-label": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/textfield/node_modules/@smui/line-ripple": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/line-ripple/-/line-ripple-7.0.0-beta.9.tgz",
-      "integrity": "sha512-GuWd+mVY1BrLi9Y0/r+5G/EzQXiGmDGxqRTSxA4Ufa6zEhGZ8bk7tHT/WvGZL/xq87MTvJ3PWOYbLbNN3gi2mg==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/line-ripple/-/line-ripple-7.0.0-beta.15.tgz",
+      "integrity": "sha512-tfdEybgQlLiotELlWknLzb5l6pT47uGfMGYzLs5AVf74CU/zAhp8NiicHUUmI95qY5P2z2xHYYpdLTs1wZ5c9A==",
       "dev": true,
       "dependencies": {
         "@material/line-ripple": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/textfield/node_modules/@smui/notched-outline": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/notched-outline/-/notched-outline-7.0.0-beta.9.tgz",
-      "integrity": "sha512-oZ8ah/9sX+QiTyJwXhrqBkrpfjxwv53zOvyZbs6bVGFi2dp/HBzGXHuoUKgfWHtE8smC6Bd675BDpig8XN86PQ==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/notched-outline/-/notched-outline-7.0.0-beta.15.tgz",
+      "integrity": "sha512-9oVSIYmb1/GcCFYm1M0xVy4J5/A2Ysa4H6gm3RIL9/ke3F9EmmALmCs1lmtGu4Vwyo0ES5KroW2Tly2SzMfB2g==",
       "dev": true,
       "dependencies": {
         "@material/notched-outline": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "@smui/floating-label": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/floating-label": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/textfield/node_modules/@smui/ripple": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.9.tgz",
-      "integrity": "sha512-N21ONk6cFMAkKfLjPDMyEKNvcAzklxpJ/TXIWQBUJxRQJZcjhPLLq9y5RpqVF+0DiIFHXm/hQJv98psPtJqHIw==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.15.tgz",
+      "integrity": "sha512-l0c94p60gxbsClH0KzA2meJ2IGHc7ZUMyWqODkLNz7ziUYxk3VZvWf/Y7Ca+64IJj0keCGPMpFauFaJO8h3Gtw==",
       "dev": true,
       "dependencies": {
         "@material/dom": "^14.0.0",
         "@material/ripple": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/textfield/node_modules/svelte2tsx": {
-      "version": "0.6.16",
-      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.16.tgz",
-      "integrity": "sha512-AX2iYEvQdd4tq5BokRdOOA0N/nD37ZnhXAomrAG9EEGl2cjkvoQUwe1Aluo6FSzA684WJjhxW+1ZXmveCmvDrA==",
+      "version": "0.6.23",
+      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.23.tgz",
+      "integrity": "sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==",
       "dev": true,
       "dependencies": {
         "dedent-js": "^1.0.1",
@@ -5424,6 +5414,39 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-colors": {
@@ -5788,12 +5811,6 @@
       "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
       "integrity": "sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ=="
     },
-    "node_modules/deep-is": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
-    },
     "node_modules/deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
@@ -5868,77 +5885,17 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/escodegen": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-      "dev": true,
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/escodegen/node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
-      "integrity": "sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A==",
-      "dev": true,
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
-    "node_modules/esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.2.11",
@@ -5955,12 +5912,6 @@
       "engines": {
         "node": ">=8.6.0"
       }
-    },
-    "node_modules/fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -6474,6 +6425,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
     "node_modules/json5": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -6496,17 +6453,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/jsonpath": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
-      "integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
-      "dev": true,
-      "dependencies": {
-        "esprima": "1.2.2",
-        "static-eval": "2.0.2",
-        "underscore": "1.12.1"
-      }
-    },
     "node_modules/klaw-sync": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
@@ -6522,19 +6468,6 @@
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-      "dev": true,
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/livereload": {
@@ -7152,23 +7085,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dev": true,
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/opts": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/opts/-/opts-2.0.2.tgz",
@@ -7381,13 +7297,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+    "node_modules/punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true,
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">=6"
       }
     },
     "node_modules/queue-microtask": {
@@ -7435,6 +7351,15 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -7934,15 +7859,6 @@
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
-    "node_modules/static-eval": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
-      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
-      "dev": true,
-      "dependencies": {
-        "escodegen": "^1.8.1"
-      }
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -8074,20 +7990,251 @@
       }
     },
     "node_modules/svelte-jsonschema-form": {
-      "version": "0.1.1",
-      "resolved": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#9b890fee199fe7e99af987b86642ab6c98485352",
+      "version": "0.6.0",
+      "resolved": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#d3247a9066399acc032c625a2af4cb99682745fa",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@json-schema-tools/dereferencer": "^1.6.1",
-        "@json-schema-tools/validator": "^1.4.0",
+        "@json-schema-tools/traverse": "^1.10.1",
+        "@smui-extra/accordion": "^7.0.0-beta.14",
+        "@smui/checkbox": "^7.0.0-beta.14",
+        "@smui/fab": "^7.0.0-beta.14",
+        "@smui/form-field": "^7.0.0-beta.14",
+        "@smui/icon-button": "^7.0.0-beta.14",
+        "@smui/paper": "^7.0.0-beta.14",
+        "@smui/select": "^7.0.0-beta.14",
+        "@smui/textfield": "^7.0.0-beta.14",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^2.1.1",
         "core-js": "^3.31.1",
+        "fast-deep-equal": "^3.1.3",
         "json-schema-merge-allof": "^0.8.1",
-        "patch-package": "^7.0.2"
+        "patch-package": "^7.0.2",
+        "svelte-portal": "^2.2.0"
       },
       "peerDependencies": {
-        "svelte": "^3.54.0"
+        "svelte": "^3.50 || ^4"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/animation": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-14.0.0.tgz",
+      "integrity": "sha512-VlYSfUaIj/BBVtRZI8Gv0VvzikFf+XgK0Zdgsok5c1v5DDnNz5tpB8mnGrveWz0rHbp1X4+CWLKrTwNmjrw3Xw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/base": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-14.0.0.tgz",
+      "integrity": "sha512-Ou7vS7n1H4Y10MUZyYAbt6H0t67c6urxoCgeVT7M38aQlaNUwFMODp7KT/myjYz2YULfhu3PtfSV3Sltgac9mA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/dom": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-14.0.0.tgz",
+      "integrity": "sha512-8t88XyacclTj8qsIw9q0vEj4PI2KVncLoIsIMzwuMx49P2FZg6TsLjor262MI3Qs00UWAifuLMrhnOnfyrbe7Q==",
+      "dev": true,
+      "dependencies": {
+        "@material/feature-targeting": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/elevation": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-14.0.0.tgz",
+      "integrity": "sha512-Di3tkxTpXwvf1GJUmaC8rd+zVh5dB2SWMBGagL4+kT8UmjSISif/OPRGuGnXs3QhF6nmEjkdC0ijdZLcYQkepw==",
+      "dev": true,
+      "dependencies": {
+        "@material/animation": "^14.0.0",
+        "@material/base": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/fab": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@material/fab/-/fab-14.0.0.tgz",
+      "integrity": "sha512-s4rrw2TLU8ITKopHSTEHuJEFsGEZsb+ijwW16pQt0h9GArxPGaALT+CCJIPjf75D3wPEEMW0vnLj7oMoII2VFg==",
+      "dev": true,
+      "dependencies": {
+        "@material/animation": "^14.0.0",
+        "@material/dom": "^14.0.0",
+        "@material/elevation": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/focus-ring": "^14.0.0",
+        "@material/ripple": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/shape": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "@material/tokens": "^14.0.0",
+        "@material/touch-target": "^14.0.0",
+        "@material/typography": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/feature-targeting": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0.tgz",
+      "integrity": "sha512-a5WGgHEq5lJeeNL5yevtgoZjBjXWy6+klfVWQEh8oyix/rMJygGgO7gEc52uv8fB8uAIoYEB3iBMOv8jRq8FeA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/ripple": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-14.0.0.tgz",
+      "integrity": "sha512-9XoGBFd5JhFgELgW7pqtiLy+CnCIcV2s9cQ2BWbOQeA8faX9UZIDUx/g76nHLZ7UzKFtsULJxZTwORmsEt2zvw==",
+      "dev": true,
+      "dependencies": {
+        "@material/animation": "^14.0.0",
+        "@material/base": "^14.0.0",
+        "@material/dom": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/rtl": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-14.0.0.tgz",
+      "integrity": "sha512-xl6OZYyRjuiW2hmbjV2omMV8sQtfmKAjeWnD1RMiAPLCTyOW9Lh/PYYnXjxUrNa0cRwIIbOn5J7OYXokja8puA==",
+      "dev": true,
+      "dependencies": {
+        "@material/theme": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/shape": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@material/shape/-/shape-14.0.0.tgz",
+      "integrity": "sha512-o0mJB0+feOv473KckI8gFnUo8IQAaEA6ynXzw3VIYFjPi48pJwrxa0mZcJP/OoTXrCbDzDeFJfDPXEmRioBb9A==",
+      "dev": true,
+      "dependencies": {
+        "@material/feature-targeting": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/theme": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0.tgz",
+      "integrity": "sha512-6/SENWNIFuXzeHMPHrYwbsXKgkvCtWuzzQ3cUu4UEt3KcQ5YpViazIM6h8ByYKZP8A9d8QpkJ0WGX5btGDcVoA==",
+      "dev": true,
+      "dependencies": {
+        "@material/feature-targeting": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/tokens": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-14.0.0.tgz",
+      "integrity": "sha512-SXgB9VwsKW4DFkHmJfDIS0x0cGdMWC1D06m6z/WQQ5P5j6/m0pKrbHVlrLzXcRjau+mFhXGvj/KyPo9Pp/Rc8Q==",
+      "dev": true,
+      "dependencies": {
+        "@material/elevation": "^14.0.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/touch-target": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-14.0.0.tgz",
+      "integrity": "sha512-o3kvxmS4HkmZoQTvtzLJrqSG+ezYXkyINm3Uiwio1PTg67pDgK5FRwInkz0VNaWPcw9+5jqjUQGjuZMtjQMq8w==",
+      "dev": true,
+      "dependencies": {
+        "@material/base": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/typography": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-14.0.0.tgz",
+      "integrity": "sha512-/QtHBYiTR+TPMryM/CT386B2WlAQf/Ae32V324Z7P40gHLKY/YBXx7FDutAWZFeOerq/two4Nd2aAHBcMM2wMw==",
+      "dev": true,
+      "dependencies": {
+        "@material/feature-targeting": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@smui-extra/accordion": {
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui-extra/accordion/-/accordion-7.0.0-beta.15.tgz",
+      "integrity": "sha512-/T5RX6akQRCuo82YMLr3VbmVOdnzO+Vn0zy0PWIOB8YqiSf6ny5T4cY3lENwN9hrAeA5JuMQ8mQbyoa2KWMgbw==",
+      "dev": true,
+      "dependencies": {
+        "@material/animation": "^14.0.0",
+        "@material/elevation": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/ripple": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "@material/typography": "^14.0.0",
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/paper": "^7.0.0-beta.15",
+        "@smui/ripple": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@smui/common": {
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
+      "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
+      "dev": true,
+      "dependencies": {
+        "@material/dom": "^14.0.0",
+        "svelte2tsx": "^0.6.21"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@smui/fab": {
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/fab/-/fab-7.0.0-beta.15.tgz",
+      "integrity": "sha512-mO7hscDVA4YslTtB4dxWLNkxl1U/ZKSskglLNKrFWvjCd/MiOSVZSyMODkGnLaeQFMfgGus7moGqS+nY+hvvsQ==",
+      "dev": true,
+      "dependencies": {
+        "@material/fab": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/ripple": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@smui/paper": {
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/paper/-/paper-7.0.0-beta.15.tgz",
+      "integrity": "sha512-qJgu41Gn/5fjhzo9rEhVnYm3U2SL9ECCD1nfmqbRMUzVlaeWrlSwWqJcJSAR6Og2ya8BYBoJetbxUdlLU8X9GA==",
+      "dev": true,
+      "dependencies": {
+        "@material/elevation": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/shape": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "@material/typography": "^14.0.0",
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@smui/ripple": {
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.15.tgz",
+      "integrity": "sha512-l0c94p60gxbsClH0KzA2meJ2IGHc7ZUMyWqODkLNz7ziUYxk3VZvWf/Y7Ca+64IJj0keCGPMpFauFaJO8h3Gtw==",
+      "dev": true,
+      "dependencies": {
+        "@material/dom": "^14.0.0",
+        "@material/ripple": "^14.0.0",
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/svelte-jsonschema-form/node_modules/ansi-styles": {
@@ -8288,6 +8435,34 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/svelte2tsx": {
+      "version": "0.6.23",
+      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.23.tgz",
+      "integrity": "sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==",
+      "dev": true,
+      "dependencies": {
+        "dedent-js": "^1.0.1",
+        "pascal-case": "^3.1.1"
+      },
+      "peerDependencies": {
+        "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0",
+        "typescript": "^4.9.4 || ^5.0.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/svelte-jsonschema-form/node_modules/universalify": {
@@ -8713,6 +8888,12 @@
         "svelte2tsx": "^0.5.12"
       }
     },
+    "node_modules/svelte-portal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/svelte-portal/-/svelte-portal-2.2.0.tgz",
+      "integrity": "sha512-jhtZWtD6cUE2nMw46dJ5VXWYiqnER+JH+V/BmNBQ5fNP/YdsJCpJi+DemUy9msklqGb0f+wLhJPBtKHLWQvzjg==",
+      "dev": true
+    },
     "node_modules/svelte-preprocess": {
       "version": "4.10.7",
       "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz",
@@ -8926,18 +9107,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
-    "node_modules/type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-      "dev": true,
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/typescript": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
@@ -8950,12 +9119,6 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==",
-      "dev": true
-    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -8963,6 +9126,15 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/validate.io-array": {
@@ -9034,15 +9206,6 @@
       },
       "bin": {
         "which": "bin/which"
-      }
-    },
-    "node_modules/word-wrap": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/workerpool": {
@@ -9364,16 +9527,6 @@
       "resolved": "https://registry.npmjs.org/@json-schema-tools/traverse/-/traverse-1.10.1.tgz",
       "integrity": "sha512-vYY5EIxCPzEXEWL/vTjdHy4g92tv1ApUQCjPJsj9gEoXLNNVwJlwwgRZisuvgFBZ3zeLzQygrbehERSpYdmFZA==",
       "dev": true
-    },
-    "@json-schema-tools/validator": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/validator/-/validator-1.4.0.tgz",
-      "integrity": "sha512-0t/dBRszJEznq96EBabltiogsWxY/O2ECa9oM85a2By6q2uARJeztymdM9gmPFi0AhxlpOIi/byZcR+4zSvIMw==",
-      "dev": true,
-      "requires": {
-        "@json-schema-tools/traverse": "^1.10.0",
-        "jsonpath": "^1.1.1"
-      }
     },
     "@material/animation": {
       "version": "13.0.0",
@@ -11829,15 +11982,15 @@
       }
     },
     "@smui/checkbox": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/checkbox/-/checkbox-7.0.0-beta.9.tgz",
-      "integrity": "sha512-LPnYywI3m4kEgskLDs48UcWz5ulIGqZ/l/tzk5/6vibq8NGLYTW6k6v5rEYx9EfoNRMN+K4QNL2AOtIL25v+CQ==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/checkbox/-/checkbox-7.0.0-beta.15.tgz",
+      "integrity": "sha512-lDRHkec8qCNz8SAdV8G1XoFLdj340OVK0KoEszo/KTu+eIfIfkiIKrvZj5TEb8ohGV1j0QuaOivlhnP+CNDERA==",
       "dev": true,
       "requires": {
         "@material/checkbox": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "@smui/ripple": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/ripple": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       },
       "dependencies": {
         "@material/animation": {
@@ -11952,31 +12105,31 @@
           }
         },
         "@smui/common": {
-          "version": "7.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.9.tgz",
-          "integrity": "sha512-Wf63UfvaB8hDSzxkoqCUpFiJffQixmyKW+mWVE5ZUQ94Vwg0gZWGbNMEBrwrtI4tHomMQ95VVNdps/KsaXlStw==",
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
+          "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
           "dev": true,
           "requires": {
             "@material/dom": "^14.0.0",
-            "svelte2tsx": "^0.6.15"
+            "svelte2tsx": "^0.6.21"
           }
         },
         "@smui/ripple": {
-          "version": "7.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.9.tgz",
-          "integrity": "sha512-N21ONk6cFMAkKfLjPDMyEKNvcAzklxpJ/TXIWQBUJxRQJZcjhPLLq9y5RpqVF+0DiIFHXm/hQJv98psPtJqHIw==",
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.15.tgz",
+          "integrity": "sha512-l0c94p60gxbsClH0KzA2meJ2IGHc7ZUMyWqODkLNz7ziUYxk3VZvWf/Y7Ca+64IJj0keCGPMpFauFaJO8h3Gtw==",
           "dev": true,
           "requires": {
             "@material/dom": "^14.0.0",
             "@material/ripple": "^14.0.0",
-            "@smui/common": "^7.0.0-beta.9",
-            "svelte2tsx": "^0.6.15"
+            "@smui/common": "^7.0.0-beta.15",
+            "svelte2tsx": "^0.6.21"
           }
         },
         "svelte2tsx": {
-          "version": "0.6.16",
-          "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.16.tgz",
-          "integrity": "sha512-AX2iYEvQdd4tq5BokRdOOA0N/nD37ZnhXAomrAG9EEGl2cjkvoQUwe1Aluo6FSzA684WJjhxW+1ZXmveCmvDrA==",
+          "version": "0.6.23",
+          "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.23.tgz",
+          "integrity": "sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==",
           "dev": true,
           "requires": {
             "dedent-js": "^1.0.1",
@@ -12518,16 +12671,16 @@
       }
     },
     "@smui/form-field": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/form-field/-/form-field-7.0.0-beta.9.tgz",
-      "integrity": "sha512-OBXImDdVm9cbHZYFIA+d5pw2MqhjJ0poBOzcXOxenzIlWUOC0ettNhvES4bjmnM1SjROi5SpSZ7DDJxkvdfxlQ==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/form-field/-/form-field-7.0.0-beta.15.tgz",
+      "integrity": "sha512-Ou2Og5pVkktrhPW0c+eA+A6O9WJrpqmOh+ZqekQfixiJRmP13645NRk3qbA0NUoIBb6m+9wJ2KbEoZ0yrHWnaw==",
       "dev": true,
       "requires": {
         "@material/feature-targeting": "^14.0.0",
         "@material/form-field": "^14.0.0",
         "@material/rtl": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       },
       "dependencies": {
         "@material/dom": {
@@ -12570,19 +12723,19 @@
           }
         },
         "@smui/common": {
-          "version": "7.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.9.tgz",
-          "integrity": "sha512-Wf63UfvaB8hDSzxkoqCUpFiJffQixmyKW+mWVE5ZUQ94Vwg0gZWGbNMEBrwrtI4tHomMQ95VVNdps/KsaXlStw==",
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
+          "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
           "dev": true,
           "requires": {
             "@material/dom": "^14.0.0",
-            "svelte2tsx": "^0.6.15"
+            "svelte2tsx": "^0.6.21"
           }
         },
         "svelte2tsx": {
-          "version": "0.6.16",
-          "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.16.tgz",
-          "integrity": "sha512-AX2iYEvQdd4tq5BokRdOOA0N/nD37ZnhXAomrAG9EEGl2cjkvoQUwe1Aluo6FSzA684WJjhxW+1ZXmveCmvDrA==",
+          "version": "0.6.23",
+          "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.23.tgz",
+          "integrity": "sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==",
           "dev": true,
           "requires": {
             "dedent-js": "^1.0.1",
@@ -12599,16 +12752,16 @@
       }
     },
     "@smui/icon-button": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/icon-button/-/icon-button-7.0.0-beta.9.tgz",
-      "integrity": "sha512-F1QmslrdIq+plkKnIvN2cyVPFish7lhw7cYzxpWzhOXbjF1Bay0mmyuHSYjiZ3//LL1CcFOnZJ/QMT8dKqfgYg==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/icon-button/-/icon-button-7.0.0-beta.15.tgz",
+      "integrity": "sha512-Hvvv9w6hDCDOrSgxlcsXrCLOE8VJeTJ5Tu1n+FBqvIfetaF7ATXDwXx+raEznJ4kZK6CyoQTzMIr2rz4hxGiMA==",
       "dev": true,
       "requires": {
         "@material/density": "^14.0.0",
         "@material/icon-button": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "@smui/ripple": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/ripple": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       },
       "dependencies": {
         "@material/animation": {
@@ -12738,31 +12891,31 @@
           }
         },
         "@smui/common": {
-          "version": "7.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.9.tgz",
-          "integrity": "sha512-Wf63UfvaB8hDSzxkoqCUpFiJffQixmyKW+mWVE5ZUQ94Vwg0gZWGbNMEBrwrtI4tHomMQ95VVNdps/KsaXlStw==",
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
+          "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
           "dev": true,
           "requires": {
             "@material/dom": "^14.0.0",
-            "svelte2tsx": "^0.6.15"
+            "svelte2tsx": "^0.6.21"
           }
         },
         "@smui/ripple": {
-          "version": "7.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.9.tgz",
-          "integrity": "sha512-N21ONk6cFMAkKfLjPDMyEKNvcAzklxpJ/TXIWQBUJxRQJZcjhPLLq9y5RpqVF+0DiIFHXm/hQJv98psPtJqHIw==",
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.15.tgz",
+          "integrity": "sha512-l0c94p60gxbsClH0KzA2meJ2IGHc7ZUMyWqODkLNz7ziUYxk3VZvWf/Y7Ca+64IJj0keCGPMpFauFaJO8h3Gtw==",
           "dev": true,
           "requires": {
             "@material/dom": "^14.0.0",
             "@material/ripple": "^14.0.0",
-            "@smui/common": "^7.0.0-beta.9",
-            "svelte2tsx": "^0.6.15"
+            "@smui/common": "^7.0.0-beta.15",
+            "svelte2tsx": "^0.6.21"
           }
         },
         "svelte2tsx": {
-          "version": "0.6.16",
-          "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.16.tgz",
-          "integrity": "sha512-AX2iYEvQdd4tq5BokRdOOA0N/nD37ZnhXAomrAG9EEGl2cjkvoQUwe1Aluo6FSzA684WJjhxW+1ZXmveCmvDrA==",
+          "version": "0.6.23",
+          "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.23.tgz",
+          "integrity": "sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==",
           "dev": true,
           "requires": {
             "dedent-js": "^1.0.1",
@@ -12819,17 +12972,17 @@
       }
     },
     "@smui/list": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/list/-/list-7.0.0-beta.9.tgz",
-      "integrity": "sha512-nSpiFK5kd+yCDrG6dJR5+flYaPiI77zeWMJzmE3XGvqXrQULjTSatCIRmgFjTJYwsDKcWb8xT7Omg7T/H+IoqQ==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/list/-/list-7.0.0-beta.15.tgz",
+      "integrity": "sha512-5NeAgVLjcaJo0Mr4IXB1QaAb3UGBtNWJqHNwVXfPpADIb3vKLNGpKrXv5koKqCLGEapkEjQ2PqixURaB/5O2eg==",
       "dev": true,
       "requires": {
         "@material/dom": "^14.0.0",
         "@material/feature-targeting": "^14.0.0",
         "@material/list": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "@smui/ripple": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/ripple": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       },
       "dependencies": {
         "@material/animation": {
@@ -12955,31 +13108,31 @@
           }
         },
         "@smui/common": {
-          "version": "7.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.9.tgz",
-          "integrity": "sha512-Wf63UfvaB8hDSzxkoqCUpFiJffQixmyKW+mWVE5ZUQ94Vwg0gZWGbNMEBrwrtI4tHomMQ95VVNdps/KsaXlStw==",
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
+          "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
           "dev": true,
           "requires": {
             "@material/dom": "^14.0.0",
-            "svelte2tsx": "^0.6.15"
+            "svelte2tsx": "^0.6.21"
           }
         },
         "@smui/ripple": {
-          "version": "7.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.9.tgz",
-          "integrity": "sha512-N21ONk6cFMAkKfLjPDMyEKNvcAzklxpJ/TXIWQBUJxRQJZcjhPLLq9y5RpqVF+0DiIFHXm/hQJv98psPtJqHIw==",
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.15.tgz",
+          "integrity": "sha512-l0c94p60gxbsClH0KzA2meJ2IGHc7ZUMyWqODkLNz7ziUYxk3VZvWf/Y7Ca+64IJj0keCGPMpFauFaJO8h3Gtw==",
           "dev": true,
           "requires": {
             "@material/dom": "^14.0.0",
             "@material/ripple": "^14.0.0",
-            "@smui/common": "^7.0.0-beta.9",
-            "svelte2tsx": "^0.6.15"
+            "@smui/common": "^7.0.0-beta.15",
+            "svelte2tsx": "^0.6.21"
           }
         },
         "svelte2tsx": {
-          "version": "0.6.16",
-          "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.16.tgz",
-          "integrity": "sha512-AX2iYEvQdd4tq5BokRdOOA0N/nD37ZnhXAomrAG9EEGl2cjkvoQUwe1Aluo6FSzA684WJjhxW+1ZXmveCmvDrA==",
+          "version": "0.6.23",
+          "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.23.tgz",
+          "integrity": "sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==",
           "dev": true,
           "requires": {
             "dedent-js": "^1.0.1",
@@ -12996,17 +13149,17 @@
       }
     },
     "@smui/menu": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/menu/-/menu-7.0.0-beta.9.tgz",
-      "integrity": "sha512-GpfDZUqSywcNrVzWmHs63uDJiVneK+WuGqC9D6l58Uj5TsPT5fr4UGFfuWAl6685pDjD3eCwEmyFdQKi3DPXfA==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/menu/-/menu-7.0.0-beta.15.tgz",
+      "integrity": "sha512-hvw8iRuWvo1Lc1O6MaAtO99vIUQMlheK5vvG046WZlzwuiZMulBvtipc74nhM69BdrTTDAob69xsZXHih3LHVw==",
       "dev": true,
       "requires": {
         "@material/dom": "^14.0.0",
         "@material/menu": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "@smui/list": "^7.0.0-beta.9",
-        "@smui/menu-surface": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/list": "^7.0.0-beta.15",
+        "@smui/menu-surface": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       },
       "dependencies": {
         "@material/animation": {
@@ -13180,31 +13333,31 @@
           }
         },
         "@smui/common": {
-          "version": "7.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.9.tgz",
-          "integrity": "sha512-Wf63UfvaB8hDSzxkoqCUpFiJffQixmyKW+mWVE5ZUQ94Vwg0gZWGbNMEBrwrtI4tHomMQ95VVNdps/KsaXlStw==",
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
+          "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
           "dev": true,
           "requires": {
             "@material/dom": "^14.0.0",
-            "svelte2tsx": "^0.6.15"
+            "svelte2tsx": "^0.6.21"
           }
         },
         "@smui/menu-surface": {
-          "version": "7.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/@smui/menu-surface/-/menu-surface-7.0.0-beta.9.tgz",
-          "integrity": "sha512-xmSyvNCVYDGYrZdZw1TXKmbX3rZYpubxiGcPXnHEElR2zljAwg9LsHKD8ZnpzJJZrpxTpO3xCrj0ybB0yYxqLA==",
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/menu-surface/-/menu-surface-7.0.0-beta.15.tgz",
+          "integrity": "sha512-fpBJD1+gBUdegMM0qoZg9Fu5j/9TfAtxDBRBqAoHWKY7sW9uqbHhV1lwkVLWs7V+PKXWamTIX37//EHSIVw0TQ==",
           "dev": true,
           "requires": {
             "@material/animation": "^14.0.0",
             "@material/menu-surface": "^14.0.0",
-            "@smui/common": "^7.0.0-beta.9",
-            "svelte2tsx": "^0.6.15"
+            "@smui/common": "^7.0.0-beta.15",
+            "svelte2tsx": "^0.6.21"
           }
         },
         "svelte2tsx": {
-          "version": "0.6.16",
-          "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.16.tgz",
-          "integrity": "sha512-AX2iYEvQdd4tq5BokRdOOA0N/nD37ZnhXAomrAG9EEGl2cjkvoQUwe1Aluo6FSzA684WJjhxW+1ZXmveCmvDrA==",
+          "version": "0.6.23",
+          "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.23.tgz",
+          "integrity": "sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==",
           "dev": true,
           "requires": {
             "dedent-js": "^1.0.1",
@@ -13404,9 +13557,9 @@
       }
     },
     "@smui/select": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/select/-/select-7.0.0-beta.9.tgz",
-      "integrity": "sha512-LB7KiOQT92j6IJAuwHIlaF7G3beLPOUqPsNB/FFN8JKpQSnjx7w7PjLvcgSLlfxkxX38XfNE1dwH8KUp4JKOhA==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/select/-/select-7.0.0-beta.15.tgz",
+      "integrity": "sha512-quYIEaFDt5aXOj3ZnV5axDDWkrkASAWcRzd/P1PQ2bCAQNaaichaUOV+2QGbYVD8G+UiRBYy8fgJMpIE9s9KUg==",
       "dev": true,
       "requires": {
         "@material/feature-targeting": "^14.0.0",
@@ -13414,15 +13567,15 @@
         "@material/rtl": "^14.0.0",
         "@material/select": "^14.0.0",
         "@material/theme": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "@smui/floating-label": "^7.0.0-beta.9",
-        "@smui/line-ripple": "^7.0.0-beta.9",
-        "@smui/list": "^7.0.0-beta.9",
-        "@smui/menu": "^7.0.0-beta.9",
-        "@smui/menu-surface": "^7.0.0-beta.9",
-        "@smui/notched-outline": "^7.0.0-beta.9",
-        "@smui/ripple": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/floating-label": "^7.0.0-beta.15",
+        "@smui/line-ripple": "^7.0.0-beta.15",
+        "@smui/list": "^7.0.0-beta.15",
+        "@smui/menu": "^7.0.0-beta.15",
+        "@smui/menu-surface": "^7.0.0-beta.15",
+        "@smui/notched-outline": "^7.0.0-beta.15",
+        "@smui/ripple": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       },
       "dependencies": {
         "@material/animation": {
@@ -13676,77 +13829,77 @@
           }
         },
         "@smui/common": {
-          "version": "7.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.9.tgz",
-          "integrity": "sha512-Wf63UfvaB8hDSzxkoqCUpFiJffQixmyKW+mWVE5ZUQ94Vwg0gZWGbNMEBrwrtI4tHomMQ95VVNdps/KsaXlStw==",
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
+          "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
           "dev": true,
           "requires": {
             "@material/dom": "^14.0.0",
-            "svelte2tsx": "^0.6.15"
+            "svelte2tsx": "^0.6.21"
           }
         },
         "@smui/floating-label": {
-          "version": "7.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/@smui/floating-label/-/floating-label-7.0.0-beta.9.tgz",
-          "integrity": "sha512-Il3ztKWBjWX3yz7pCZq9C4DpUzRZ4ewKMA6YQ5uqsWRn/crVHPCk5irSVc3chZ7jGHZ6ZvbUYn7qGTv8OlVobg==",
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/floating-label/-/floating-label-7.0.0-beta.15.tgz",
+          "integrity": "sha512-KRjZjO8AGE5uKHewmn05vyAxIi6XOGo8a4jn8b0+dIJcYxaPpmtacH4PeQHw4vOR88cX/0DqqxSz6+Fkrt+SIA==",
           "dev": true,
           "requires": {
             "@material/floating-label": "^14.0.0",
-            "@smui/common": "^7.0.0-beta.9",
-            "svelte2tsx": "^0.6.15"
+            "@smui/common": "^7.0.0-beta.15",
+            "svelte2tsx": "^0.6.21"
           }
         },
         "@smui/line-ripple": {
-          "version": "7.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/@smui/line-ripple/-/line-ripple-7.0.0-beta.9.tgz",
-          "integrity": "sha512-GuWd+mVY1BrLi9Y0/r+5G/EzQXiGmDGxqRTSxA4Ufa6zEhGZ8bk7tHT/WvGZL/xq87MTvJ3PWOYbLbNN3gi2mg==",
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/line-ripple/-/line-ripple-7.0.0-beta.15.tgz",
+          "integrity": "sha512-tfdEybgQlLiotELlWknLzb5l6pT47uGfMGYzLs5AVf74CU/zAhp8NiicHUUmI95qY5P2z2xHYYpdLTs1wZ5c9A==",
           "dev": true,
           "requires": {
             "@material/line-ripple": "^14.0.0",
-            "@smui/common": "^7.0.0-beta.9",
-            "svelte2tsx": "^0.6.15"
+            "@smui/common": "^7.0.0-beta.15",
+            "svelte2tsx": "^0.6.21"
           }
         },
         "@smui/menu-surface": {
-          "version": "7.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/@smui/menu-surface/-/menu-surface-7.0.0-beta.9.tgz",
-          "integrity": "sha512-xmSyvNCVYDGYrZdZw1TXKmbX3rZYpubxiGcPXnHEElR2zljAwg9LsHKD8ZnpzJJZrpxTpO3xCrj0ybB0yYxqLA==",
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/menu-surface/-/menu-surface-7.0.0-beta.15.tgz",
+          "integrity": "sha512-fpBJD1+gBUdegMM0qoZg9Fu5j/9TfAtxDBRBqAoHWKY7sW9uqbHhV1lwkVLWs7V+PKXWamTIX37//EHSIVw0TQ==",
           "dev": true,
           "requires": {
             "@material/animation": "^14.0.0",
             "@material/menu-surface": "^14.0.0",
-            "@smui/common": "^7.0.0-beta.9",
-            "svelte2tsx": "^0.6.15"
+            "@smui/common": "^7.0.0-beta.15",
+            "svelte2tsx": "^0.6.21"
           }
         },
         "@smui/notched-outline": {
-          "version": "7.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/@smui/notched-outline/-/notched-outline-7.0.0-beta.9.tgz",
-          "integrity": "sha512-oZ8ah/9sX+QiTyJwXhrqBkrpfjxwv53zOvyZbs6bVGFi2dp/HBzGXHuoUKgfWHtE8smC6Bd675BDpig8XN86PQ==",
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/notched-outline/-/notched-outline-7.0.0-beta.15.tgz",
+          "integrity": "sha512-9oVSIYmb1/GcCFYm1M0xVy4J5/A2Ysa4H6gm3RIL9/ke3F9EmmALmCs1lmtGu4Vwyo0ES5KroW2Tly2SzMfB2g==",
           "dev": true,
           "requires": {
             "@material/notched-outline": "^14.0.0",
-            "@smui/common": "^7.0.0-beta.9",
-            "@smui/floating-label": "^7.0.0-beta.9",
-            "svelte2tsx": "^0.6.15"
+            "@smui/common": "^7.0.0-beta.15",
+            "@smui/floating-label": "^7.0.0-beta.15",
+            "svelte2tsx": "^0.6.21"
           }
         },
         "@smui/ripple": {
-          "version": "7.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.9.tgz",
-          "integrity": "sha512-N21ONk6cFMAkKfLjPDMyEKNvcAzklxpJ/TXIWQBUJxRQJZcjhPLLq9y5RpqVF+0DiIFHXm/hQJv98psPtJqHIw==",
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.15.tgz",
+          "integrity": "sha512-l0c94p60gxbsClH0KzA2meJ2IGHc7ZUMyWqODkLNz7ziUYxk3VZvWf/Y7Ca+64IJj0keCGPMpFauFaJO8h3Gtw==",
           "dev": true,
           "requires": {
             "@material/dom": "^14.0.0",
             "@material/ripple": "^14.0.0",
-            "@smui/common": "^7.0.0-beta.9",
-            "svelte2tsx": "^0.6.15"
+            "@smui/common": "^7.0.0-beta.15",
+            "svelte2tsx": "^0.6.21"
           }
         },
         "svelte2tsx": {
-          "version": "0.6.16",
-          "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.16.tgz",
-          "integrity": "sha512-AX2iYEvQdd4tq5BokRdOOA0N/nD37ZnhXAomrAG9EEGl2cjkvoQUwe1Aluo6FSzA684WJjhxW+1ZXmveCmvDrA==",
+          "version": "0.6.23",
+          "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.23.tgz",
+          "integrity": "sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==",
           "dev": true,
           "requires": {
             "dedent-js": "^1.0.1",
@@ -14067,9 +14220,9 @@
       }
     },
     "@smui/textfield": {
-      "version": "7.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@smui/textfield/-/textfield-7.0.0-beta.9.tgz",
-      "integrity": "sha512-H/fXDjvg9QtOwAfzsbesOOre20dTBKRqWyNaWL4riIg6paDtDV9tdgQuugxwC+h/8dT3n8j69NidRshxmNuPQA==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/textfield/-/textfield-7.0.0-beta.15.tgz",
+      "integrity": "sha512-98lGaVJRH3K5aXVUAa8o/8rHRQ/Vwu9q6phupSrPW4BEmEEEezb/fzKExTOgm0c241dy4nDRLkdH9IdtObTA8w==",
       "dev": true,
       "requires": {
         "@material/dom": "^14.0.0",
@@ -14077,12 +14230,12 @@
         "@material/ripple": "^14.0.0",
         "@material/rtl": "^14.0.0",
         "@material/textfield": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.9",
-        "@smui/floating-label": "^7.0.0-beta.9",
-        "@smui/line-ripple": "^7.0.0-beta.9",
-        "@smui/notched-outline": "^7.0.0-beta.9",
-        "@smui/ripple": "^7.0.0-beta.9",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/floating-label": "^7.0.0-beta.15",
+        "@smui/line-ripple": "^7.0.0-beta.15",
+        "@smui/notched-outline": "^7.0.0-beta.15",
+        "@smui/ripple": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       },
       "dependencies": {
         "@material/animation": {
@@ -14225,65 +14378,65 @@
           }
         },
         "@smui/common": {
-          "version": "7.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.9.tgz",
-          "integrity": "sha512-Wf63UfvaB8hDSzxkoqCUpFiJffQixmyKW+mWVE5ZUQ94Vwg0gZWGbNMEBrwrtI4tHomMQ95VVNdps/KsaXlStw==",
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
+          "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
           "dev": true,
           "requires": {
             "@material/dom": "^14.0.0",
-            "svelte2tsx": "^0.6.15"
+            "svelte2tsx": "^0.6.21"
           }
         },
         "@smui/floating-label": {
-          "version": "7.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/@smui/floating-label/-/floating-label-7.0.0-beta.9.tgz",
-          "integrity": "sha512-Il3ztKWBjWX3yz7pCZq9C4DpUzRZ4ewKMA6YQ5uqsWRn/crVHPCk5irSVc3chZ7jGHZ6ZvbUYn7qGTv8OlVobg==",
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/floating-label/-/floating-label-7.0.0-beta.15.tgz",
+          "integrity": "sha512-KRjZjO8AGE5uKHewmn05vyAxIi6XOGo8a4jn8b0+dIJcYxaPpmtacH4PeQHw4vOR88cX/0DqqxSz6+Fkrt+SIA==",
           "dev": true,
           "requires": {
             "@material/floating-label": "^14.0.0",
-            "@smui/common": "^7.0.0-beta.9",
-            "svelte2tsx": "^0.6.15"
+            "@smui/common": "^7.0.0-beta.15",
+            "svelte2tsx": "^0.6.21"
           }
         },
         "@smui/line-ripple": {
-          "version": "7.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/@smui/line-ripple/-/line-ripple-7.0.0-beta.9.tgz",
-          "integrity": "sha512-GuWd+mVY1BrLi9Y0/r+5G/EzQXiGmDGxqRTSxA4Ufa6zEhGZ8bk7tHT/WvGZL/xq87MTvJ3PWOYbLbNN3gi2mg==",
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/line-ripple/-/line-ripple-7.0.0-beta.15.tgz",
+          "integrity": "sha512-tfdEybgQlLiotELlWknLzb5l6pT47uGfMGYzLs5AVf74CU/zAhp8NiicHUUmI95qY5P2z2xHYYpdLTs1wZ5c9A==",
           "dev": true,
           "requires": {
             "@material/line-ripple": "^14.0.0",
-            "@smui/common": "^7.0.0-beta.9",
-            "svelte2tsx": "^0.6.15"
+            "@smui/common": "^7.0.0-beta.15",
+            "svelte2tsx": "^0.6.21"
           }
         },
         "@smui/notched-outline": {
-          "version": "7.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/@smui/notched-outline/-/notched-outline-7.0.0-beta.9.tgz",
-          "integrity": "sha512-oZ8ah/9sX+QiTyJwXhrqBkrpfjxwv53zOvyZbs6bVGFi2dp/HBzGXHuoUKgfWHtE8smC6Bd675BDpig8XN86PQ==",
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/notched-outline/-/notched-outline-7.0.0-beta.15.tgz",
+          "integrity": "sha512-9oVSIYmb1/GcCFYm1M0xVy4J5/A2Ysa4H6gm3RIL9/ke3F9EmmALmCs1lmtGu4Vwyo0ES5KroW2Tly2SzMfB2g==",
           "dev": true,
           "requires": {
             "@material/notched-outline": "^14.0.0",
-            "@smui/common": "^7.0.0-beta.9",
-            "@smui/floating-label": "^7.0.0-beta.9",
-            "svelte2tsx": "^0.6.15"
+            "@smui/common": "^7.0.0-beta.15",
+            "@smui/floating-label": "^7.0.0-beta.15",
+            "svelte2tsx": "^0.6.21"
           }
         },
         "@smui/ripple": {
-          "version": "7.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.9.tgz",
-          "integrity": "sha512-N21ONk6cFMAkKfLjPDMyEKNvcAzklxpJ/TXIWQBUJxRQJZcjhPLLq9y5RpqVF+0DiIFHXm/hQJv98psPtJqHIw==",
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.15.tgz",
+          "integrity": "sha512-l0c94p60gxbsClH0KzA2meJ2IGHc7ZUMyWqODkLNz7ziUYxk3VZvWf/Y7Ca+64IJj0keCGPMpFauFaJO8h3Gtw==",
           "dev": true,
           "requires": {
             "@material/dom": "^14.0.0",
             "@material/ripple": "^14.0.0",
-            "@smui/common": "^7.0.0-beta.9",
-            "svelte2tsx": "^0.6.15"
+            "@smui/common": "^7.0.0-beta.15",
+            "svelte2tsx": "^0.6.21"
           }
         },
         "svelte2tsx": {
-          "version": "0.6.16",
-          "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.16.tgz",
-          "integrity": "sha512-AX2iYEvQdd4tq5BokRdOOA0N/nD37ZnhXAomrAG9EEGl2cjkvoQUwe1Aluo6FSzA684WJjhxW+1ZXmveCmvDrA==",
+          "version": "0.6.23",
+          "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.23.tgz",
+          "integrity": "sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==",
           "dev": true,
           "requires": {
             "dedent-js": "^1.0.1",
@@ -14453,6 +14606,27 @@
       "dev": true,
       "requires": {
         "debug": "4"
+      }
+    },
+    "ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.0"
       }
     },
     "ansi-colors": {
@@ -14738,12 +14912,6 @@
       "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
       "integrity": "sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ=="
     },
-    "deep-is": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
-    },
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
@@ -14805,49 +14973,16 @@
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true
     },
-    "escodegen": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-      "dev": true,
-      "requires": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-          "dev": true
-        }
-      }
-    },
-    "esprima": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
-      "integrity": "sha512-+JpPZam9w5DuJ3Q67SqsMGtiHKENSMRVoxvArfJZK01/BfLEObtZ6orJa/MtoGNR/rfMgp5837T41PAmTwAv/A==",
-      "dev": true
-    },
-    "estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true
-    },
     "estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
-    "esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
     "fast-glob": {
@@ -14862,12 +14997,6 @@
         "merge2": "^1.3.0",
         "micromatch": "^4.0.4"
       }
-    },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true
     },
     "fast-safe-stringify": {
       "version": "2.1.1",
@@ -15262,6 +15391,12 @@
         "lodash": "^4.17.20"
       }
     },
+    "json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
     "json5": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -15281,17 +15416,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "jsonpath": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
-      "integrity": "sha512-l6Cg7jRpixfbgoWgkrl77dgEj8RPvND0wMH6TwQmi9Qs4TFfS9u5cUFnbeKTwj5ga5Y3BTGGNI28k117LJ009w==",
-      "dev": true,
-      "requires": {
-        "esprima": "1.2.2",
-        "static-eval": "2.0.2",
-        "underscore": "1.12.1"
-      }
-    },
     "klaw-sync": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
@@ -15305,16 +15429,6 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="
-    },
-    "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      }
     },
     "livereload": {
       "version": "0.9.3",
@@ -15775,20 +15889,6 @@
         "is-wsl": "^2.1.1"
       }
     },
-    "optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dev": true,
-      "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      }
-    },
     "opts": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/opts/-/opts-2.0.2.tgz",
@@ -15932,10 +16032,10 @@
         }
       }
     },
-    "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+    "punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true
     },
     "queue-microtask": {
@@ -15966,6 +16066,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
     "resolve": {
@@ -16326,15 +16432,6 @@
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
-    "static-eval": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
-      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
-      "dev": true,
-      "requires": {
-        "escodegen": "^1.8.1"
-      }
-    },
     "string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -16430,17 +16527,248 @@
       }
     },
     "svelte-jsonschema-form": {
-      "version": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#9b890fee199fe7e99af987b86642ab6c98485352",
+      "version": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#d3247a9066399acc032c625a2af4cb99682745fa",
       "dev": true,
       "from": "svelte-jsonschema-form@github:webgme/svelte-jsonschema-form",
       "requires": {
         "@json-schema-tools/dereferencer": "^1.6.1",
-        "@json-schema-tools/validator": "^1.4.0",
+        "@json-schema-tools/traverse": "^1.10.1",
+        "@smui-extra/accordion": "^7.0.0-beta.14",
+        "@smui/checkbox": "^7.0.0-beta.14",
+        "@smui/fab": "^7.0.0-beta.14",
+        "@smui/form-field": "^7.0.0-beta.14",
+        "@smui/icon-button": "^7.0.0-beta.14",
+        "@smui/paper": "^7.0.0-beta.14",
+        "@smui/select": "^7.0.0-beta.14",
+        "@smui/textfield": "^7.0.0-beta.14",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^2.1.1",
         "core-js": "^3.31.1",
+        "fast-deep-equal": "^3.1.3",
         "json-schema-merge-allof": "^0.8.1",
-        "patch-package": "^7.0.2"
+        "patch-package": "^7.0.2",
+        "svelte-portal": "^2.2.0"
       },
       "dependencies": {
+        "@material/animation": {
+          "version": "14.0.0",
+          "resolved": "https://registry.npmjs.org/@material/animation/-/animation-14.0.0.tgz",
+          "integrity": "sha512-VlYSfUaIj/BBVtRZI8Gv0VvzikFf+XgK0Zdgsok5c1v5DDnNz5tpB8mnGrveWz0rHbp1X4+CWLKrTwNmjrw3Xw==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/base": {
+          "version": "14.0.0",
+          "resolved": "https://registry.npmjs.org/@material/base/-/base-14.0.0.tgz",
+          "integrity": "sha512-Ou7vS7n1H4Y10MUZyYAbt6H0t67c6urxoCgeVT7M38aQlaNUwFMODp7KT/myjYz2YULfhu3PtfSV3Sltgac9mA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/dom": {
+          "version": "14.0.0",
+          "resolved": "https://registry.npmjs.org/@material/dom/-/dom-14.0.0.tgz",
+          "integrity": "sha512-8t88XyacclTj8qsIw9q0vEj4PI2KVncLoIsIMzwuMx49P2FZg6TsLjor262MI3Qs00UWAifuLMrhnOnfyrbe7Q==",
+          "dev": true,
+          "requires": {
+            "@material/feature-targeting": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/elevation": {
+          "version": "14.0.0",
+          "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-14.0.0.tgz",
+          "integrity": "sha512-Di3tkxTpXwvf1GJUmaC8rd+zVh5dB2SWMBGagL4+kT8UmjSISif/OPRGuGnXs3QhF6nmEjkdC0ijdZLcYQkepw==",
+          "dev": true,
+          "requires": {
+            "@material/animation": "^14.0.0",
+            "@material/base": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/fab": {
+          "version": "14.0.0",
+          "resolved": "https://registry.npmjs.org/@material/fab/-/fab-14.0.0.tgz",
+          "integrity": "sha512-s4rrw2TLU8ITKopHSTEHuJEFsGEZsb+ijwW16pQt0h9GArxPGaALT+CCJIPjf75D3wPEEMW0vnLj7oMoII2VFg==",
+          "dev": true,
+          "requires": {
+            "@material/animation": "^14.0.0",
+            "@material/dom": "^14.0.0",
+            "@material/elevation": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/focus-ring": "^14.0.0",
+            "@material/ripple": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "@material/shape": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "@material/tokens": "^14.0.0",
+            "@material/touch-target": "^14.0.0",
+            "@material/typography": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/feature-targeting": {
+          "version": "14.0.0",
+          "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0.tgz",
+          "integrity": "sha512-a5WGgHEq5lJeeNL5yevtgoZjBjXWy6+klfVWQEh8oyix/rMJygGgO7gEc52uv8fB8uAIoYEB3iBMOv8jRq8FeA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/ripple": {
+          "version": "14.0.0",
+          "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-14.0.0.tgz",
+          "integrity": "sha512-9XoGBFd5JhFgELgW7pqtiLy+CnCIcV2s9cQ2BWbOQeA8faX9UZIDUx/g76nHLZ7UzKFtsULJxZTwORmsEt2zvw==",
+          "dev": true,
+          "requires": {
+            "@material/animation": "^14.0.0",
+            "@material/base": "^14.0.0",
+            "@material/dom": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/rtl": {
+          "version": "14.0.0",
+          "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-14.0.0.tgz",
+          "integrity": "sha512-xl6OZYyRjuiW2hmbjV2omMV8sQtfmKAjeWnD1RMiAPLCTyOW9Lh/PYYnXjxUrNa0cRwIIbOn5J7OYXokja8puA==",
+          "dev": true,
+          "requires": {
+            "@material/theme": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/shape": {
+          "version": "14.0.0",
+          "resolved": "https://registry.npmjs.org/@material/shape/-/shape-14.0.0.tgz",
+          "integrity": "sha512-o0mJB0+feOv473KckI8gFnUo8IQAaEA6ynXzw3VIYFjPi48pJwrxa0mZcJP/OoTXrCbDzDeFJfDPXEmRioBb9A==",
+          "dev": true,
+          "requires": {
+            "@material/feature-targeting": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/theme": {
+          "version": "14.0.0",
+          "resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0.tgz",
+          "integrity": "sha512-6/SENWNIFuXzeHMPHrYwbsXKgkvCtWuzzQ3cUu4UEt3KcQ5YpViazIM6h8ByYKZP8A9d8QpkJ0WGX5btGDcVoA==",
+          "dev": true,
+          "requires": {
+            "@material/feature-targeting": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/tokens": {
+          "version": "14.0.0",
+          "resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-14.0.0.tgz",
+          "integrity": "sha512-SXgB9VwsKW4DFkHmJfDIS0x0cGdMWC1D06m6z/WQQ5P5j6/m0pKrbHVlrLzXcRjau+mFhXGvj/KyPo9Pp/Rc8Q==",
+          "dev": true,
+          "requires": {
+            "@material/elevation": "^14.0.0"
+          }
+        },
+        "@material/touch-target": {
+          "version": "14.0.0",
+          "resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-14.0.0.tgz",
+          "integrity": "sha512-o3kvxmS4HkmZoQTvtzLJrqSG+ezYXkyINm3Uiwio1PTg67pDgK5FRwInkz0VNaWPcw9+5jqjUQGjuZMtjQMq8w==",
+          "dev": true,
+          "requires": {
+            "@material/base": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/typography": {
+          "version": "14.0.0",
+          "resolved": "https://registry.npmjs.org/@material/typography/-/typography-14.0.0.tgz",
+          "integrity": "sha512-/QtHBYiTR+TPMryM/CT386B2WlAQf/Ae32V324Z7P40gHLKY/YBXx7FDutAWZFeOerq/two4Nd2aAHBcMM2wMw==",
+          "dev": true,
+          "requires": {
+            "@material/feature-targeting": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@smui-extra/accordion": {
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui-extra/accordion/-/accordion-7.0.0-beta.15.tgz",
+          "integrity": "sha512-/T5RX6akQRCuo82YMLr3VbmVOdnzO+Vn0zy0PWIOB8YqiSf6ny5T4cY3lENwN9hrAeA5JuMQ8mQbyoa2KWMgbw==",
+          "dev": true,
+          "requires": {
+            "@material/animation": "^14.0.0",
+            "@material/elevation": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/ripple": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "@material/typography": "^14.0.0",
+            "@smui/common": "^7.0.0-beta.15",
+            "@smui/paper": "^7.0.0-beta.15",
+            "@smui/ripple": "^7.0.0-beta.15",
+            "svelte2tsx": "^0.6.21"
+          }
+        },
+        "@smui/common": {
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
+          "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
+          "dev": true,
+          "requires": {
+            "@material/dom": "^14.0.0",
+            "svelte2tsx": "^0.6.21"
+          }
+        },
+        "@smui/fab": {
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/fab/-/fab-7.0.0-beta.15.tgz",
+          "integrity": "sha512-mO7hscDVA4YslTtB4dxWLNkxl1U/ZKSskglLNKrFWvjCd/MiOSVZSyMODkGnLaeQFMfgGus7moGqS+nY+hvvsQ==",
+          "dev": true,
+          "requires": {
+            "@material/fab": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@smui/common": "^7.0.0-beta.15",
+            "@smui/ripple": "^7.0.0-beta.15",
+            "svelte2tsx": "^0.6.21"
+          }
+        },
+        "@smui/paper": {
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/paper/-/paper-7.0.0-beta.15.tgz",
+          "integrity": "sha512-qJgu41Gn/5fjhzo9rEhVnYm3U2SL9ECCD1nfmqbRMUzVlaeWrlSwWqJcJSAR6Og2ya8BYBoJetbxUdlLU8X9GA==",
+          "dev": true,
+          "requires": {
+            "@material/elevation": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/shape": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "@material/typography": "^14.0.0",
+            "@smui/common": "^7.0.0-beta.15",
+            "svelte2tsx": "^0.6.21"
+          }
+        },
+        "@smui/ripple": {
+          "version": "7.0.0-beta.15",
+          "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.15.tgz",
+          "integrity": "sha512-l0c94p60gxbsClH0KzA2meJ2IGHc7ZUMyWqODkLNz7ziUYxk3VZvWf/Y7Ca+64IJj0keCGPMpFauFaJO8h3Gtw==",
+          "dev": true,
+          "requires": {
+            "@material/dom": "^14.0.0",
+            "@material/ripple": "^14.0.0",
+            "@smui/common": "^7.0.0-beta.15",
+            "svelte2tsx": "^0.6.21"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -16580,6 +16908,23 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "svelte2tsx": {
+          "version": "0.6.23",
+          "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.23.tgz",
+          "integrity": "sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==",
+          "dev": true,
+          "requires": {
+            "dedent-js": "^1.0.1",
+            "pascal-case": "^3.1.1"
+          }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         },
         "universalify": {
           "version": "2.0.0",
@@ -16999,6 +17344,12 @@
         }
       }
     },
+    "svelte-portal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/svelte-portal/-/svelte-portal-2.2.0.tgz",
+      "integrity": "sha512-jhtZWtD6cUE2nMw46dJ5VXWYiqnER+JH+V/BmNBQ5fNP/YdsJCpJi+DemUy9msklqGb0f+wLhJPBtKHLWQvzjg==",
+      "dev": true
+    },
     "svelte-preprocess": {
       "version": "4.10.7",
       "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz",
@@ -17120,31 +17471,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
-    "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "~1.1.2"
-      }
-    },
     "typescript": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
-    },
-    "underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==",
-      "dev": true
     },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
     },
     "validate.io-array": {
       "version": "1.0.6",
@@ -17213,12 +17558,6 @@
       "requires": {
         "isexe": "^2.0.0"
       }
-    },
-    "word-wrap": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-      "dev": true
     },
     "workerpool": {
       "version": "6.2.1",

--- a/src/routers/Search/dashboard/package-lock.json
+++ b/src/routers/Search/dashboard/package-lock.json
@@ -7916,8 +7916,8 @@
       }
     },
     "node_modules/svelte-jsonschema-form": {
-      "version": "0.5.3",
-      "resolved": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#d2ba3e08504bea55c95b6097554d223abd5616f2",
+      "version": "0.6.0",
+      "resolved": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#d3247a9066399acc032c625a2af4cb99682745fa",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -16391,7 +16391,7 @@
       }
     },
     "svelte-jsonschema-form": {
-      "version": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#d2ba3e08504bea55c95b6097554d223abd5616f2",
+      "version": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#d3247a9066399acc032c625a2af4cb99682745fa",
       "dev": true,
       "from": "svelte-jsonschema-form@github:webgme/svelte-jsonschema-form",
       "requires": {

--- a/src/routers/Search/dashboard/src/components/TagSelector.svelte
+++ b/src/routers/Search/dashboard/src/components/TagSelector.svelte
@@ -62,21 +62,11 @@
     <a
       target="_blank"
       href={window.location.href
-        .replace("/Search/", "/TagCreatorv1/")
-        .replace(
-          /[^\/]*\/static\//,
-          `${encodeURIComponent(contentType.nodePath)}/static/`
-        )}>Click to select tags for the {displayTypeName}.</a
-    >
-    <br/>
-    <a
-      target="_blank"
-      href={window.location.href
         .replace("/Search/", "/TagCreator/")
         .replace(
           /[^\/]*\/static\//,
           `${encodeURIComponent(contentType.nodePath)}/static/`
-        )}>Click to try the new tag form (experimental).</a
+        )}>Click to select tags for the {displayTypeName}.</a
     >
 </div>
 

--- a/src/routers/TagCreator/form/package-lock.json
+++ b/src/routers/TagCreator/form/package-lock.json
@@ -2835,8 +2835,8 @@
       }
     },
     "node_modules/svelte-jsonschema-form": {
-      "version": "0.5.0",
-      "resolved": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#55e18a4c20fa37437060a936cf30a5b97c312760",
+      "version": "0.6.0",
+      "resolved": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#d3247a9066399acc032c625a2af4cb99682745fa",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2856,11 +2856,18 @@
         "core-js": "^3.31.1",
         "fast-deep-equal": "^3.1.3",
         "json-schema-merge-allof": "^0.8.1",
-        "patch-package": "^7.0.2"
+        "patch-package": "^7.0.2",
+        "svelte-portal": "^2.2.0"
       },
       "peerDependencies": {
         "svelte": "^3.50 || ^4"
       }
+    },
+    "node_modules/svelte-portal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/svelte-portal/-/svelte-portal-2.2.0.tgz",
+      "integrity": "sha512-jhtZWtD6cUE2nMw46dJ5VXWYiqnER+JH+V/BmNBQ5fNP/YdsJCpJi+DemUy9msklqGb0f+wLhJPBtKHLWQvzjg==",
+      "dev": true
     },
     "node_modules/svelte-preprocess": {
       "version": "5.0.4",
@@ -5401,7 +5408,7 @@
       "requires": {}
     },
     "svelte-jsonschema-form": {
-      "version": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#55e18a4c20fa37437060a936cf30a5b97c312760",
+      "version": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#d3247a9066399acc032c625a2af4cb99682745fa",
       "dev": true,
       "from": "svelte-jsonschema-form@github:webgme/svelte-jsonschema-form",
       "requires": {
@@ -5420,8 +5427,15 @@
         "core-js": "^3.31.1",
         "fast-deep-equal": "^3.1.3",
         "json-schema-merge-allof": "^0.8.1",
-        "patch-package": "^7.0.2"
+        "patch-package": "^7.0.2",
+        "svelte-portal": "^2.2.0"
       }
+    },
+    "svelte-portal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/svelte-portal/-/svelte-portal-2.2.0.tgz",
+      "integrity": "sha512-jhtZWtD6cUE2nMw46dJ5VXWYiqnER+JH+V/BmNBQ5fNP/YdsJCpJi+DemUy9msklqGb0f+wLhJPBtKHLWQvzjg==",
+      "dev": true
     },
     "svelte-preprocess": {
       "version": "5.0.4",


### PR DESCRIPTION
Updates version of svelte-jsonschema-form dependency.

Removes "experimental" link for tag form from dashboard.

refs #235 