### PR TITLE
Remove PDP prefix from files in file stream; simplify logic in directory creation

### DIFF
--- a/src/routers/Search/src/TaskQueue.ts
+++ b/src/routers/Search/src/TaskQueue.ts
@@ -117,17 +117,9 @@ export class DownloadTask implements Runnable<FilePath> {
           contentId,
         );
 
-        // create the directories
+        // create the main content directory
         const contentDir = path.join(downloadDir, contentName);
         await fsp.mkdir(contentDir);
-        const dirs = new Set(
-          Object.keys(streamDict)
-            .map((filepath) => path.dirname(filepath))
-            .sort(cmp.length),
-        );
-        await Promise.all(
-          [...dirs].map((dir) => fsp.mkdir(dir, { recursive: true })),
-        );
 
         // add the metadata file
         const contentMetadata = metadata[index];
@@ -148,8 +140,8 @@ export class DownloadTask implements Runnable<FilePath> {
         await Promise.all(
           Object.entries(streamDict).map(async ([name, dataStream]) => {
             const filePath = path.join(downloadDir, contentName, name);
+            await fsp.mkdir(path.dirname(filePath), { recursive: true });
             const writeStream = fs.createWriteStream(filePath);
-            console.log("writing to", filePath);
             await streamPipeline(dataStream, writeStream);
           }),
         );

--- a/src/routers/Search/src/adapters/PDP/api.ts
+++ b/src/routers/Search/src/adapters/PDP/api.ts
@@ -438,6 +438,8 @@ export class InMemoryPdp implements PdpProvider {
             })),
           },
         };
+        const index = data.observations.length;
+        const version = 0;
         data.observations.push(obsDatum);
         data.state.numObservations = data.observations.length;
         const response: AppendObservationResponse = Object.assign(
@@ -446,7 +448,7 @@ export class InMemoryPdp implements PdpProvider {
           { // the new field in the append response
             uploadDataFiles: {
               files: obsDatum.fileData.files.map((fdata) => ({
-                name: `dat/${fdata.name}`,
+                name: `dat/${index}/${version}/${fdata.name}`,
                 sasUrl: fdata.sasUrl,
               })),
             },

--- a/src/routers/Search/src/adapters/PDP/index.ts
+++ b/src/routers/Search/src/adapters/PDP/index.ts
@@ -218,19 +218,11 @@ export default class PDP implements Adapter {
       downloadInfo.files.map(async (fileInfo) => {
         const { name, url } = fileInfo;
         const response = await fetch(url);
-        console.log(
-          "fetching",
-          name,
-          "from",
-          url,
-          "is response ok?",
-          response.ok,
-        );
         if (!response.ok) {
           // FIXME: should this be a user error?
           throw new RouterUtils.UserError("Unable to retrieve file: " + name);
         }
-        return [name, response.body];
+        return [PDP.getOriginalFilePath(name), response.body];
       }),
     );
     return Object.fromEntries(entries);
@@ -373,13 +365,20 @@ export default class PDP implements Adapter {
 
     console.log(JSON.stringify(result));
     const files = result.uploadDataFiles.files.map((file) => {
-      // name is prefixed with dat/index/version/<rest of path>
-      const name = file.name.split("/").slice(3).join("/");
+      const name = PDP.getOriginalFilePath(file.name);
       const params = new UploadParams(file.sasUrl, "PUT", UPLOAD_HEADERS);
       return new UploadRequest(name, params);
     });
 
     return new AppendResult(index, files);
+  }
+
+  /**
+   * Files stored on PDP have a prefix appended: "dat/<index>/<version>/<original>".
+   * This method strips this prefix from the string.
+   */
+  static getOriginalFilePath(pdpPath: string): string {
+    return pdpPath.replace(/^dat\/\d+\/\d+\//, "");
   }
 
   async _downloadFile(filePath: string, url: string) {

--- a/test/routers/Search/adapters/PDP/index.spec.js
+++ b/test/routers/Search/adapters/PDP/index.spec.js
@@ -10,6 +10,14 @@ describe("PDP", function () {
   const assert = require("assert");
   const processType = "someProcessType";
 
+  describe("getOriginalFilePath", function () {
+    it("should strip prefix from filenames", function () {
+      const original = "a/b/cat.txt";
+      const filename = "dat/0/100/" + original;
+      assert.equal(PDP.getOriginalFilePath(filename), original);
+    });
+  });
+
   describe("appendArtifact", function () {
     beforeEach(() => {
       const api = new InMemoryPdp();


### PR DESCRIPTION
Fix #447
