### PR TITLE
Update svelte-jsonschema-form

### DIFF
--- a/src/routers/Insights/dashboard/package-lock.json
+++ b/src/routers/Insights/dashboard/package-lock.json
@@ -48,7 +48,6 @@
         "svelte-check": "^2.0.0",
         "svelte-echarts": "^0.0.5",
         "svelte-file-dropzone": "^1.0.0",
-        "svelte-jsonschema-form": "github:webgme/svelte-jsonschema-form#v0.6.0",
         "svelte-preprocess": "^4.0.0",
         "ts-mocha": "^10.0.0",
         "tslib": "^2.0.0",
@@ -152,39 +151,6 @@
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
-    },
-    "node_modules/@json-schema-spec/json-pointer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@json-schema-spec/json-pointer/-/json-pointer-0.1.2.tgz",
-      "integrity": "sha512-BYY7IavBjwsWWSmVcMz2A9mKiDD9RvacnsItgmy1xV8cmgbtxFfKmKMtkVpD7pYtkx4mIW4800yZBXueVFIWPw==",
-      "dev": true
-    },
-    "node_modules/@json-schema-tools/dereferencer": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/dereferencer/-/dereferencer-1.6.1.tgz",
-      "integrity": "sha512-+h+K/H3pWoJVztTuz1ycTUc0ai/xH5eLZLurE4jQpqYwPcPvsXtFfbRxDhvxrrpjjg4PV3HmEjjORIEQPO4Dmw==",
-      "dev": true,
-      "dependencies": {
-        "@json-schema-tools/reference-resolver": "^1.2.5",
-        "@json-schema-tools/traverse": "^1.10.0",
-        "fast-safe-stringify": "^2.1.1"
-      }
-    },
-    "node_modules/@json-schema-tools/reference-resolver": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/reference-resolver/-/reference-resolver-1.2.5.tgz",
-      "integrity": "sha512-xNQgX/ABnwvbIeexL5Czv08lXjHAL80HEUogza7E19eIL/EXD8HM4FvxG1JuTGyi5fA+sSP64C9pabELizcBBw==",
-      "dev": true,
-      "dependencies": {
-        "@json-schema-spec/json-pointer": "^0.1.2",
-        "isomorphic-fetch": "^3.0.0"
-      }
-    },
-    "node_modules/@json-schema-tools/traverse": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/traverse/-/traverse-1.10.1.tgz",
-      "integrity": "sha512-vYY5EIxCPzEXEWL/vTjdHy4g92tv1ApUQCjPJsj9gEoXLNNVwJlwwgRZisuvgFBZ3zeLzQygrbehERSpYdmFZA==",
       "dev": true
     },
     "node_modules/@material/animation": {
@@ -2653,6 +2619,20 @@
         "typescript": "^4.9.4 || ^5.0.0"
       }
     },
+    "node_modules/@smui/card/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@smui/checkbox": {
       "version": "7.0.0-beta.15",
       "resolved": "https://registry.npmjs.org/@smui/checkbox/-/checkbox-7.0.0-beta.15.tgz",
@@ -2812,6 +2792,20 @@
         "typescript": "^4.9.4 || ^5.0.0"
       }
     },
+    "node_modules/@smui/checkbox/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@smui/chips": {
       "version": "7.0.0-beta.9",
       "resolved": "https://registry.npmjs.org/@smui/chips/-/chips-7.0.0-beta.9.tgz",
@@ -2932,6 +2926,20 @@
       "peerDependencies": {
         "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0",
         "typescript": "^4.9.4 || ^5.0.0"
+      }
+    },
+    "node_modules/@smui/chips/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@smui/circular-progress": {
@@ -3241,6 +3249,20 @@
         "typescript": "^4.9.4 || ^5.0.0"
       }
     },
+    "node_modules/@smui/dialog/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@smui/drawer": {
       "version": "7.0.0-beta.9",
       "resolved": "https://registry.npmjs.org/@smui/drawer/-/drawer-7.0.0-beta.9.tgz",
@@ -3294,6 +3316,20 @@
       "peerDependencies": {
         "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0",
         "typescript": "^4.9.4 || ^5.0.0"
+      }
+    },
+    "node_modules/@smui/drawer/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@smui/fab": {
@@ -3392,6 +3428,20 @@
       "peerDependencies": {
         "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0",
         "typescript": "^4.9.4 || ^5.0.0"
+      }
+    },
+    "node_modules/@smui/form-field/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@smui/icon-button": {
@@ -3567,6 +3617,20 @@
       "peerDependencies": {
         "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0",
         "typescript": "^4.9.4 || ^5.0.0"
+      }
+    },
+    "node_modules/@smui/icon-button/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@smui/image-list": {
@@ -3779,6 +3843,20 @@
       "peerDependencies": {
         "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0",
         "typescript": "^4.9.4 || ^5.0.0"
+      }
+    },
+    "node_modules/@smui/list/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@smui/menu": {
@@ -4012,6 +4090,20 @@
         "typescript": "^4.9.4 || ^5.0.0"
       }
     },
+    "node_modules/@smui/menu/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@smui/notched-outline": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/@smui/notched-outline/-/notched-outline-6.1.4.tgz",
@@ -4155,6 +4247,20 @@
       "peerDependencies": {
         "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0",
         "typescript": "^4.9.4 || ^5.0.0"
+      }
+    },
+    "node_modules/@smui/radio/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@smui/ripple": {
@@ -4533,6 +4639,20 @@
         "typescript": "^4.9.4 || ^5.0.0"
       }
     },
+    "node_modules/@smui/select/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@smui/slider": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@smui/slider/-/slider-6.0.0.tgz",
@@ -4772,6 +4892,20 @@
       "peerDependencies": {
         "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0",
         "typescript": "^4.9.4 || ^5.0.0"
+      }
+    },
+    "node_modules/@smui/snackbar/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@smui/switch": {
@@ -5060,6 +5194,20 @@
         "typescript": "^4.9.4 || ^5.0.0"
       }
     },
+    "node_modules/@smui/textfield/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@smui/tooltip": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@smui/tooltip/-/tooltip-6.0.0.tgz",
@@ -5123,6 +5271,20 @@
       "peerDependencies": {
         "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0",
         "typescript": "^4.9.4 || ^5.0.0"
+      }
+    },
+    "node_modules/@smui/top-app-bar/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@smui/touch-target": {
@@ -5220,37 +5382,14 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+    "node_modules/ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
@@ -5287,6 +5426,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -5294,15 +5440,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -5342,6 +5479,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -5376,6 +5520,19 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/carbon-components-svelte": {
@@ -5434,6 +5591,18 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
     },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -5461,29 +5630,6 @@
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
-    "node_modules/compute-gcd": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
-      "integrity": "sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==",
-      "dev": true,
-      "dependencies": {
-        "validate.io-array": "^1.0.3",
-        "validate.io-function": "^1.0.2",
-        "validate.io-integer-array": "^1.0.0"
-      }
-    },
-    "node_modules/compute-lcm": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.2.tgz",
-      "integrity": "sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==",
-      "dev": true,
-      "dependencies": {
-        "compute-gcd": "^1.2.1",
-        "validate.io-array": "^1.0.3",
-        "validate.io-function": "^1.0.2",
-        "validate.io-integer-array": "^1.0.0"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5496,17 +5642,6 @@
       "integrity": "sha512-pMD+MVR538ipqkG5JXeOEbKWS5um1H4LUUccUQG68qpeqBYbzYy79Gh55jkd2TtPdRfUaLWdv6LPP//5Zt0aPQ==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/core-js": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.0.tgz",
-      "integrity": "sha512-rd4rYZNlF3WuoYuRIDEmbR/ga9CeuWX9U05umAvgrrZoHY4Z++cp/xwPQMvUpBB4Ag6J8KfD80G0zwCyaSxDww==",
-      "dev": true,
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/cross-spawn": {
@@ -5548,6 +5683,19 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent-js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
@@ -5569,6 +5717,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/echarts": {
@@ -5623,12 +5781,6 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
-    },
     "node_modules/fast-glob": {
       "version": "3.2.11",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
@@ -5644,12 +5796,6 @@
       "engines": {
         "node": ">=8.6.0"
       }
-    },
-    "node_modules/fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -5721,6 +5867,16 @@
       "dev": true,
       "dependencies": {
         "micromatch": "^4.0.2"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "flat": "cli.js"
       }
     },
     "node_modules/flatpickr": {
@@ -5851,6 +6007,16 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -6000,6 +6166,16 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-reference": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -6007,6 +6183,19 @@
       "dev": true,
       "dependencies": {
         "@types/estree": "*"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-wsl": {
@@ -6026,16 +6215,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
-    },
-    "node_modules/isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
     },
     "node_modules/jest-worker": {
       "version": "26.6.2",
@@ -6078,34 +6257,18 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
-    "node_modules/json-schema-compare": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
-      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
-        "lodash": "^4.17.4"
-      }
-    },
-    "node_modules/json-schema-merge-allof": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.8.1.tgz",
-      "integrity": "sha512-CTUKmIlPJbsWfzRRnOXz+0MjIqvnleIXwFTzz+t9T86HnYX/Rozria6ZVGLktAU9e+NygNljveP+yxqtQp/Q4w==",
-      "dev": true,
-      "dependencies": {
-        "compute-lcm": "^1.1.2",
-        "json-schema-compare": "^0.2.2",
-        "lodash": "^4.17.20"
+        "argparse": "^2.0.1"
       },
-      "engines": {
-        "node": ">=12.0.0"
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
     },
     "node_modules/json5": {
       "version": "1.0.1",
@@ -6190,11 +6353,98 @@
         "node": ">=8"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/log-symbols/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-symbols/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
@@ -6322,6 +6572,247 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/mocha": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "5.0.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.3",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "workerpool": "6.2.1",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/mocha/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mocha/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/mocha/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -6336,6 +6827,26 @@
       "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/nice-try": {
@@ -6569,15 +7080,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6623,15 +7125,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -7179,6 +7672,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -7207,7 +7713,6 @@
       "version": "3.59.2",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.59.2.tgz",
       "integrity": "sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -7247,492 +7752,6 @@
       "dev": true,
       "dependencies": {
         "file-selector": "^0.2.4"
-      }
-    },
-    "node_modules/svelte-jsonschema-form": {
-      "version": "0.6.0",
-      "resolved": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#d3247a9066399acc032c625a2af4cb99682745fa",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@json-schema-tools/dereferencer": "^1.6.1",
-        "@json-schema-tools/traverse": "^1.10.1",
-        "@smui-extra/accordion": "^7.0.0-beta.14",
-        "@smui/checkbox": "^7.0.0-beta.14",
-        "@smui/fab": "^7.0.0-beta.14",
-        "@smui/form-field": "^7.0.0-beta.14",
-        "@smui/icon-button": "^7.0.0-beta.14",
-        "@smui/paper": "^7.0.0-beta.14",
-        "@smui/select": "^7.0.0-beta.14",
-        "@smui/textfield": "^7.0.0-beta.14",
-        "ajv": "^8.12.0",
-        "ajv-formats": "^2.1.1",
-        "core-js": "^3.31.1",
-        "fast-deep-equal": "^3.1.3",
-        "json-schema-merge-allof": "^0.8.1",
-        "patch-package": "^7.0.2",
-        "svelte-portal": "^2.2.0"
-      },
-      "peerDependencies": {
-        "svelte": "^3.50 || ^4"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/@material/animation": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-14.0.0.tgz",
-      "integrity": "sha512-VlYSfUaIj/BBVtRZI8Gv0VvzikFf+XgK0Zdgsok5c1v5DDnNz5tpB8mnGrveWz0rHbp1X4+CWLKrTwNmjrw3Xw==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/@material/base": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/base/-/base-14.0.0.tgz",
-      "integrity": "sha512-Ou7vS7n1H4Y10MUZyYAbt6H0t67c6urxoCgeVT7M38aQlaNUwFMODp7KT/myjYz2YULfhu3PtfSV3Sltgac9mA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/@material/dom": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-14.0.0.tgz",
-      "integrity": "sha512-8t88XyacclTj8qsIw9q0vEj4PI2KVncLoIsIMzwuMx49P2FZg6TsLjor262MI3Qs00UWAifuLMrhnOnfyrbe7Q==",
-      "dev": true,
-      "dependencies": {
-        "@material/feature-targeting": "^14.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/@material/elevation": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-14.0.0.tgz",
-      "integrity": "sha512-Di3tkxTpXwvf1GJUmaC8rd+zVh5dB2SWMBGagL4+kT8UmjSISif/OPRGuGnXs3QhF6nmEjkdC0ijdZLcYQkepw==",
-      "dev": true,
-      "dependencies": {
-        "@material/animation": "^14.0.0",
-        "@material/base": "^14.0.0",
-        "@material/feature-targeting": "^14.0.0",
-        "@material/rtl": "^14.0.0",
-        "@material/theme": "^14.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/@material/fab": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/fab/-/fab-14.0.0.tgz",
-      "integrity": "sha512-s4rrw2TLU8ITKopHSTEHuJEFsGEZsb+ijwW16pQt0h9GArxPGaALT+CCJIPjf75D3wPEEMW0vnLj7oMoII2VFg==",
-      "dev": true,
-      "dependencies": {
-        "@material/animation": "^14.0.0",
-        "@material/dom": "^14.0.0",
-        "@material/elevation": "^14.0.0",
-        "@material/feature-targeting": "^14.0.0",
-        "@material/focus-ring": "^14.0.0",
-        "@material/ripple": "^14.0.0",
-        "@material/rtl": "^14.0.0",
-        "@material/shape": "^14.0.0",
-        "@material/theme": "^14.0.0",
-        "@material/tokens": "^14.0.0",
-        "@material/touch-target": "^14.0.0",
-        "@material/typography": "^14.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/@material/feature-targeting": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0.tgz",
-      "integrity": "sha512-a5WGgHEq5lJeeNL5yevtgoZjBjXWy6+klfVWQEh8oyix/rMJygGgO7gEc52uv8fB8uAIoYEB3iBMOv8jRq8FeA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/@material/ripple": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-14.0.0.tgz",
-      "integrity": "sha512-9XoGBFd5JhFgELgW7pqtiLy+CnCIcV2s9cQ2BWbOQeA8faX9UZIDUx/g76nHLZ7UzKFtsULJxZTwORmsEt2zvw==",
-      "dev": true,
-      "dependencies": {
-        "@material/animation": "^14.0.0",
-        "@material/base": "^14.0.0",
-        "@material/dom": "^14.0.0",
-        "@material/feature-targeting": "^14.0.0",
-        "@material/rtl": "^14.0.0",
-        "@material/theme": "^14.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/@material/rtl": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-14.0.0.tgz",
-      "integrity": "sha512-xl6OZYyRjuiW2hmbjV2omMV8sQtfmKAjeWnD1RMiAPLCTyOW9Lh/PYYnXjxUrNa0cRwIIbOn5J7OYXokja8puA==",
-      "dev": true,
-      "dependencies": {
-        "@material/theme": "^14.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/@material/shape": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/shape/-/shape-14.0.0.tgz",
-      "integrity": "sha512-o0mJB0+feOv473KckI8gFnUo8IQAaEA6ynXzw3VIYFjPi48pJwrxa0mZcJP/OoTXrCbDzDeFJfDPXEmRioBb9A==",
-      "dev": true,
-      "dependencies": {
-        "@material/feature-targeting": "^14.0.0",
-        "@material/rtl": "^14.0.0",
-        "@material/theme": "^14.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/@material/theme": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0.tgz",
-      "integrity": "sha512-6/SENWNIFuXzeHMPHrYwbsXKgkvCtWuzzQ3cUu4UEt3KcQ5YpViazIM6h8ByYKZP8A9d8QpkJ0WGX5btGDcVoA==",
-      "dev": true,
-      "dependencies": {
-        "@material/feature-targeting": "^14.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/@material/tokens": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-14.0.0.tgz",
-      "integrity": "sha512-SXgB9VwsKW4DFkHmJfDIS0x0cGdMWC1D06m6z/WQQ5P5j6/m0pKrbHVlrLzXcRjau+mFhXGvj/KyPo9Pp/Rc8Q==",
-      "dev": true,
-      "dependencies": {
-        "@material/elevation": "^14.0.0"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/@material/touch-target": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-14.0.0.tgz",
-      "integrity": "sha512-o3kvxmS4HkmZoQTvtzLJrqSG+ezYXkyINm3Uiwio1PTg67pDgK5FRwInkz0VNaWPcw9+5jqjUQGjuZMtjQMq8w==",
-      "dev": true,
-      "dependencies": {
-        "@material/base": "^14.0.0",
-        "@material/feature-targeting": "^14.0.0",
-        "@material/rtl": "^14.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/@material/typography": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-14.0.0.tgz",
-      "integrity": "sha512-/QtHBYiTR+TPMryM/CT386B2WlAQf/Ae32V324Z7P40gHLKY/YBXx7FDutAWZFeOerq/two4Nd2aAHBcMM2wMw==",
-      "dev": true,
-      "dependencies": {
-        "@material/feature-targeting": "^14.0.0",
-        "@material/theme": "^14.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/@smui-extra/accordion": {
-      "version": "7.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@smui-extra/accordion/-/accordion-7.0.0-beta.15.tgz",
-      "integrity": "sha512-/T5RX6akQRCuo82YMLr3VbmVOdnzO+Vn0zy0PWIOB8YqiSf6ny5T4cY3lENwN9hrAeA5JuMQ8mQbyoa2KWMgbw==",
-      "dev": true,
-      "dependencies": {
-        "@material/animation": "^14.0.0",
-        "@material/elevation": "^14.0.0",
-        "@material/feature-targeting": "^14.0.0",
-        "@material/ripple": "^14.0.0",
-        "@material/theme": "^14.0.0",
-        "@material/typography": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.15",
-        "@smui/paper": "^7.0.0-beta.15",
-        "@smui/ripple": "^7.0.0-beta.15",
-        "svelte2tsx": "^0.6.21"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/@smui/common": {
-      "version": "7.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
-      "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
-      "dev": true,
-      "dependencies": {
-        "@material/dom": "^14.0.0",
-        "svelte2tsx": "^0.6.21"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/@smui/fab": {
-      "version": "7.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@smui/fab/-/fab-7.0.0-beta.15.tgz",
-      "integrity": "sha512-mO7hscDVA4YslTtB4dxWLNkxl1U/ZKSskglLNKrFWvjCd/MiOSVZSyMODkGnLaeQFMfgGus7moGqS+nY+hvvsQ==",
-      "dev": true,
-      "dependencies": {
-        "@material/fab": "^14.0.0",
-        "@material/feature-targeting": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.15",
-        "@smui/ripple": "^7.0.0-beta.15",
-        "svelte2tsx": "^0.6.21"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/@smui/paper": {
-      "version": "7.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@smui/paper/-/paper-7.0.0-beta.15.tgz",
-      "integrity": "sha512-qJgu41Gn/5fjhzo9rEhVnYm3U2SL9ECCD1nfmqbRMUzVlaeWrlSwWqJcJSAR6Og2ya8BYBoJetbxUdlLU8X9GA==",
-      "dev": true,
-      "dependencies": {
-        "@material/elevation": "^14.0.0",
-        "@material/feature-targeting": "^14.0.0",
-        "@material/shape": "^14.0.0",
-        "@material/theme": "^14.0.0",
-        "@material/typography": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.15",
-        "svelte2tsx": "^0.6.21"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/@smui/ripple": {
-      "version": "7.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.15.tgz",
-      "integrity": "sha512-l0c94p60gxbsClH0KzA2meJ2IGHc7ZUMyWqODkLNz7ziUYxk3VZvWf/Y7Ca+64IJj0keCGPMpFauFaJO8h3Gtw==",
-      "dev": true,
-      "dependencies": {
-        "@material/dom": "^14.0.0",
-        "@material/ripple": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.15",
-        "svelte2tsx": "^0.6.21"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/ci-info": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
-      "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/patch-package": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-7.0.2.tgz",
-      "integrity": "sha512-PMYfL8LXxGIRmxXLqlEaBxzKPu7/SdP13ld6GSfAUJUZRmBDPp8chZs0dpzaAFn9TSPnFiMwkC6PJt6pBiAl8Q==",
-      "dev": true,
-      "dependencies": {
-        "@yarnpkg/lockfile": "^1.1.0",
-        "chalk": "^4.1.2",
-        "ci-info": "^3.7.0",
-        "cross-spawn": "^7.0.3",
-        "find-yarn-workspace-root": "^2.0.0",
-        "fs-extra": "^9.0.0",
-        "klaw-sync": "^6.0.0",
-        "minimist": "^1.2.6",
-        "open": "^7.4.2",
-        "rimraf": "^2.6.3",
-        "semver": "^7.5.3",
-        "slash": "^2.0.0",
-        "tmp": "^0.0.33",
-        "yaml": "^2.2.2"
-      },
-      "bin": {
-        "patch-package": "index.js"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">5"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/svelte2tsx": {
-      "version": "0.6.23",
-      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.23.tgz",
-      "integrity": "sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==",
-      "dev": true,
-      "dependencies": {
-        "dedent-js": "^1.0.1",
-        "pascal-case": "^3.1.1"
-      },
-      "peerDependencies": {
-        "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0",
-        "typescript": "^4.9.4 || ^5.0.0"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/svelte-jsonschema-form/node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/svelte-material-ui": {
@@ -8134,12 +8153,6 @@
         "svelte2tsx": "^0.5.12"
       }
     },
-    "node_modules/svelte-portal": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/svelte-portal/-/svelte-portal-2.2.0.tgz",
-      "integrity": "sha512-jhtZWtD6cUE2nMw46dJ5VXWYiqnER+JH+V/BmNBQ5fNP/YdsJCpJi+DemUy9msklqGb0f+wLhJPBtKHLWQvzjg==",
-      "dev": true
-    },
     "node_modules/svelte-preprocess": {
       "version": "4.10.7",
       "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz",
@@ -8357,7 +8370,6 @@
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8375,62 +8387,10 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/validate.io-array": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
-      "integrity": "sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg==",
-      "dev": true
-    },
-    "node_modules/validate.io-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
-      "integrity": "sha512-LlFybRJEriSuBnUhQyG5bwglhh50EpTL2ul23MPIuR1odjO7XaMLFV8vHGwp7AZciFxtYOeiSCT5st+XSPONiQ==",
-      "dev": true
-    },
-    "node_modules/validate.io-integer": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
-      "integrity": "sha512-22izsYSLojN/P6bppBqhgUDjCkr5RY2jd+N2a3DCAUey8ydvrZ/OkGvFPR7qfOpwR2LC5p4Ngzxz36g5Vgr/hQ==",
-      "dev": true,
-      "dependencies": {
-        "validate.io-number": "^1.0.3"
-      }
-    },
-    "node_modules/validate.io-integer-array": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
-      "integrity": "sha512-mTrMk/1ytQHtCY0oNO3dztafHYyGU88KL+jRxWuzfOmQb+4qqnWmI+gykvGp8usKZOM0H7keJHEbRaFiYA0VrA==",
-      "dev": true,
-      "dependencies": {
-        "validate.io-array": "^1.0.3",
-        "validate.io-integer": "^1.0.4"
-      }
-    },
-    "node_modules/validate.io-number": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
-      "integrity": "sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg==",
-      "dev": true
-    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.17",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.17.tgz",
-      "integrity": "sha512-c4ghIvG6th0eudYwKZY5keb81wtFz9/WeAHAoy8+r18kcWlitUIrmGFQ2rWEl4UCKUilD3zCLHOIPheHx5ypRQ==",
       "dev": true
     },
     "node_modules/whatwg-url": {
@@ -8454,6 +8414,13 @@
       "bin": {
         "which": "bin/which"
       }
+    },
+    "node_modules/workerpool": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -8547,15 +8514,6 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
-    "node_modules/yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -8583,6 +8541,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yargs/node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -8604,6 +8578,19 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zrender": {
@@ -8705,39 +8692,6 @@
           "dev": true
         }
       }
-    },
-    "@json-schema-spec/json-pointer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@json-schema-spec/json-pointer/-/json-pointer-0.1.2.tgz",
-      "integrity": "sha512-BYY7IavBjwsWWSmVcMz2A9mKiDD9RvacnsItgmy1xV8cmgbtxFfKmKMtkVpD7pYtkx4mIW4800yZBXueVFIWPw==",
-      "dev": true
-    },
-    "@json-schema-tools/dereferencer": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/dereferencer/-/dereferencer-1.6.1.tgz",
-      "integrity": "sha512-+h+K/H3pWoJVztTuz1ycTUc0ai/xH5eLZLurE4jQpqYwPcPvsXtFfbRxDhvxrrpjjg4PV3HmEjjORIEQPO4Dmw==",
-      "dev": true,
-      "requires": {
-        "@json-schema-tools/reference-resolver": "^1.2.5",
-        "@json-schema-tools/traverse": "^1.10.0",
-        "fast-safe-stringify": "^2.1.1"
-      }
-    },
-    "@json-schema-tools/reference-resolver": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/reference-resolver/-/reference-resolver-1.2.5.tgz",
-      "integrity": "sha512-xNQgX/ABnwvbIeexL5Czv08lXjHAL80HEUogza7E19eIL/EXD8HM4FvxG1JuTGyi5fA+sSP64C9pabELizcBBw==",
-      "dev": true,
-      "requires": {
-        "@json-schema-spec/json-pointer": "^0.1.2",
-        "isomorphic-fetch": "^3.0.0"
-      }
-    },
-    "@json-schema-tools/traverse": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/traverse/-/traverse-1.10.1.tgz",
-      "integrity": "sha512-vYY5EIxCPzEXEWL/vTjdHy4g92tv1ApUQCjPJsj9gEoXLNNVwJlwwgRZisuvgFBZ3zeLzQygrbehERSpYdmFZA==",
-      "dev": true
     },
     "@material/animation": {
       "version": "13.0.0",
@@ -11182,6 +11136,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -11339,6 +11300,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -11459,6 +11427,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -11768,6 +11743,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -11821,6 +11803,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -11917,6 +11906,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -12090,6 +12086,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -12300,6 +12303,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -12518,6 +12528,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -12672,6 +12689,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -13046,6 +13070,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -13285,6 +13316,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -13569,6 +13607,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -13632,6 +13677,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -13721,26 +13773,12 @@
         "debug": "4"
       }
     },
-    "ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true,
-      "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      }
-    },
-    "ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dev": true,
-      "requires": {
-        "ajv": "^8.0.0"
-      }
+      "peer": true
     },
     "ansi-regex": {
       "version": "5.0.1",
@@ -13767,16 +13805,17 @@
         "picomatch": "^2.0.4"
       }
     },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "peer": true
+    },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-      "dev": true
-    },
-    "at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
     },
     "balanced-match": {
@@ -13810,6 +13849,13 @@
         "fill-range": "^7.0.1"
       }
     },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "peer": true
+    },
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -13833,6 +13879,13 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
+    },
+    "camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "peer": true
     },
     "carbon-components-svelte": {
       "version": "0.67.4",
@@ -13876,6 +13929,18 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
     },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -13903,29 +13968,6 @@
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
-    "compute-gcd": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
-      "integrity": "sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==",
-      "dev": true,
-      "requires": {
-        "validate.io-array": "^1.0.3",
-        "validate.io-function": "^1.0.2",
-        "validate.io-integer-array": "^1.0.0"
-      }
-    },
-    "compute-lcm": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.2.tgz",
-      "integrity": "sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==",
-      "dev": true,
-      "requires": {
-        "compute-gcd": "^1.2.1",
-        "validate.io-array": "^1.0.3",
-        "validate.io-function": "^1.0.2",
-        "validate.io-integer-array": "^1.0.0"
-      }
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -13936,12 +13978,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/console-clear/-/console-clear-1.1.1.tgz",
       "integrity": "sha512-pMD+MVR538ipqkG5JXeOEbKWS5um1H4LUUccUQG68qpeqBYbzYy79Gh55jkd2TtPdRfUaLWdv6LPP//5Zt0aPQ=="
-    },
-    "core-js": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.0.tgz",
-      "integrity": "sha512-rd4rYZNlF3WuoYuRIDEmbR/ga9CeuWX9U05umAvgrrZoHY4Z++cp/xwPQMvUpBB4Ag6J8KfD80G0zwCyaSxDww==",
-      "dev": true
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -13973,6 +14009,13 @@
         }
       }
     },
+    "decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "peer": true
+    },
     "dedent-js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
@@ -13989,6 +14032,13 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
       "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
       "dev": true
+    },
+    "diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "peer": true
     },
     "echarts": {
       "version": "5.4.3",
@@ -14038,12 +14088,6 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
-    "fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
-    },
     "fast-glob": {
       "version": "3.2.11",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
@@ -14056,12 +14100,6 @@
         "merge2": "^1.3.0",
         "micromatch": "^4.0.4"
       }
-    },
-    "fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true
     },
     "fastq": {
       "version": "1.13.0",
@@ -14119,6 +14157,13 @@
       "requires": {
         "micromatch": "^4.0.2"
       }
+    },
+    "flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "peer": true
     },
     "flatpickr": {
       "version": "4.6.9",
@@ -14215,6 +14260,13 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "peer": true
     },
     "https-proxy-agent": {
       "version": "5.0.1",
@@ -14324,6 +14376,13 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "peer": true
+    },
     "is-reference": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -14332,6 +14391,13 @@
       "requires": {
         "@types/estree": "*"
       }
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "peer": true
     },
     "is-wsl": {
       "version": "2.2.0",
@@ -14347,16 +14413,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
-    },
-    "isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
     },
     "jest-worker": {
       "version": "26.6.2",
@@ -14392,31 +14448,15 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
-    "json-schema-compare": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
-      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
+      "peer": true,
       "requires": {
-        "lodash": "^4.17.4"
+        "argparse": "^2.0.1"
       }
-    },
-    "json-schema-merge-allof": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.8.1.tgz",
-      "integrity": "sha512-CTUKmIlPJbsWfzRRnOXz+0MjIqvnleIXwFTzz+t9T86HnYX/Rozria6ZVGLktAU9e+NygNljveP+yxqtQp/Q4w==",
-      "dev": true,
-      "requires": {
-        "compute-lcm": "^1.1.2",
-        "json-schema-compare": "^0.2.2",
-        "lodash": "^4.17.20"
-      }
-    },
-    "json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
     },
     "json5": {
       "version": "1.0.1",
@@ -14483,11 +14523,73 @@
         "p-locate": "^4.1.0"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+    "log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "peer": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "peer": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "lower-case": {
       "version": "2.0.2",
@@ -14590,6 +14692,185 @@
         "minimist": "^1.2.6"
       }
     },
+    "mocha": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "5.0.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.3",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "workerpool": "6.2.1",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true,
+          "peer": true
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          },
+          "dependencies": {
+            "minimatch": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+              "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            }
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "peer": true
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+              "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "balanced-match": "^1.0.0"
+              }
+            }
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "serialize-javascript": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+          "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
     "mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -14599,6 +14880,20 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
       "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw=="
+    },
+    "ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "peer": true
+    },
+    "nanoid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+      "dev": true,
+      "peer": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -14769,12 +15064,6 @@
         "find-up": "^4.0.0"
       }
     },
-    "punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "dev": true
-    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -14803,12 +15092,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true
-    },
-    "require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
     "resolve": {
@@ -15205,6 +15488,13 @@
         "min-indent": "^1.0.0"
       }
     },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "peer": true
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -15223,8 +15513,7 @@
     "svelte": {
       "version": "3.59.2",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.59.2.tgz",
-      "integrity": "sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==",
-      "dev": true
+      "integrity": "sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA=="
     },
     "svelte-check": {
       "version": "2.8.0",
@@ -15255,416 +15544,6 @@
       "dev": true,
       "requires": {
         "file-selector": "^0.2.4"
-      }
-    },
-    "svelte-jsonschema-form": {
-      "version": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#d3247a9066399acc032c625a2af4cb99682745fa",
-      "dev": true,
-      "from": "svelte-jsonschema-form@github:webgme/svelte-jsonschema-form#v0.6.0",
-      "requires": {
-        "@json-schema-tools/dereferencer": "^1.6.1",
-        "@json-schema-tools/traverse": "^1.10.1",
-        "@smui-extra/accordion": "^7.0.0-beta.14",
-        "@smui/checkbox": "^7.0.0-beta.14",
-        "@smui/fab": "^7.0.0-beta.14",
-        "@smui/form-field": "^7.0.0-beta.14",
-        "@smui/icon-button": "^7.0.0-beta.14",
-        "@smui/paper": "^7.0.0-beta.14",
-        "@smui/select": "^7.0.0-beta.14",
-        "@smui/textfield": "^7.0.0-beta.14",
-        "ajv": "^8.12.0",
-        "ajv-formats": "^2.1.1",
-        "core-js": "^3.31.1",
-        "fast-deep-equal": "^3.1.3",
-        "json-schema-merge-allof": "^0.8.1",
-        "patch-package": "^7.0.2",
-        "svelte-portal": "^2.2.0"
-      },
-      "dependencies": {
-        "@material/animation": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/animation/-/animation-14.0.0.tgz",
-          "integrity": "sha512-VlYSfUaIj/BBVtRZI8Gv0VvzikFf+XgK0Zdgsok5c1v5DDnNz5tpB8mnGrveWz0rHbp1X4+CWLKrTwNmjrw3Xw==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        },
-        "@material/base": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/base/-/base-14.0.0.tgz",
-          "integrity": "sha512-Ou7vS7n1H4Y10MUZyYAbt6H0t67c6urxoCgeVT7M38aQlaNUwFMODp7KT/myjYz2YULfhu3PtfSV3Sltgac9mA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        },
-        "@material/dom": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/dom/-/dom-14.0.0.tgz",
-          "integrity": "sha512-8t88XyacclTj8qsIw9q0vEj4PI2KVncLoIsIMzwuMx49P2FZg6TsLjor262MI3Qs00UWAifuLMrhnOnfyrbe7Q==",
-          "dev": true,
-          "requires": {
-            "@material/feature-targeting": "^14.0.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@material/elevation": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-14.0.0.tgz",
-          "integrity": "sha512-Di3tkxTpXwvf1GJUmaC8rd+zVh5dB2SWMBGagL4+kT8UmjSISif/OPRGuGnXs3QhF6nmEjkdC0ijdZLcYQkepw==",
-          "dev": true,
-          "requires": {
-            "@material/animation": "^14.0.0",
-            "@material/base": "^14.0.0",
-            "@material/feature-targeting": "^14.0.0",
-            "@material/rtl": "^14.0.0",
-            "@material/theme": "^14.0.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@material/fab": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/fab/-/fab-14.0.0.tgz",
-          "integrity": "sha512-s4rrw2TLU8ITKopHSTEHuJEFsGEZsb+ijwW16pQt0h9GArxPGaALT+CCJIPjf75D3wPEEMW0vnLj7oMoII2VFg==",
-          "dev": true,
-          "requires": {
-            "@material/animation": "^14.0.0",
-            "@material/dom": "^14.0.0",
-            "@material/elevation": "^14.0.0",
-            "@material/feature-targeting": "^14.0.0",
-            "@material/focus-ring": "^14.0.0",
-            "@material/ripple": "^14.0.0",
-            "@material/rtl": "^14.0.0",
-            "@material/shape": "^14.0.0",
-            "@material/theme": "^14.0.0",
-            "@material/tokens": "^14.0.0",
-            "@material/touch-target": "^14.0.0",
-            "@material/typography": "^14.0.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@material/feature-targeting": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0.tgz",
-          "integrity": "sha512-a5WGgHEq5lJeeNL5yevtgoZjBjXWy6+klfVWQEh8oyix/rMJygGgO7gEc52uv8fB8uAIoYEB3iBMOv8jRq8FeA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        },
-        "@material/ripple": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-14.0.0.tgz",
-          "integrity": "sha512-9XoGBFd5JhFgELgW7pqtiLy+CnCIcV2s9cQ2BWbOQeA8faX9UZIDUx/g76nHLZ7UzKFtsULJxZTwORmsEt2zvw==",
-          "dev": true,
-          "requires": {
-            "@material/animation": "^14.0.0",
-            "@material/base": "^14.0.0",
-            "@material/dom": "^14.0.0",
-            "@material/feature-targeting": "^14.0.0",
-            "@material/rtl": "^14.0.0",
-            "@material/theme": "^14.0.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@material/rtl": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-14.0.0.tgz",
-          "integrity": "sha512-xl6OZYyRjuiW2hmbjV2omMV8sQtfmKAjeWnD1RMiAPLCTyOW9Lh/PYYnXjxUrNa0cRwIIbOn5J7OYXokja8puA==",
-          "dev": true,
-          "requires": {
-            "@material/theme": "^14.0.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@material/shape": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/shape/-/shape-14.0.0.tgz",
-          "integrity": "sha512-o0mJB0+feOv473KckI8gFnUo8IQAaEA6ynXzw3VIYFjPi48pJwrxa0mZcJP/OoTXrCbDzDeFJfDPXEmRioBb9A==",
-          "dev": true,
-          "requires": {
-            "@material/feature-targeting": "^14.0.0",
-            "@material/rtl": "^14.0.0",
-            "@material/theme": "^14.0.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@material/theme": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0.tgz",
-          "integrity": "sha512-6/SENWNIFuXzeHMPHrYwbsXKgkvCtWuzzQ3cUu4UEt3KcQ5YpViazIM6h8ByYKZP8A9d8QpkJ0WGX5btGDcVoA==",
-          "dev": true,
-          "requires": {
-            "@material/feature-targeting": "^14.0.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@material/tokens": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-14.0.0.tgz",
-          "integrity": "sha512-SXgB9VwsKW4DFkHmJfDIS0x0cGdMWC1D06m6z/WQQ5P5j6/m0pKrbHVlrLzXcRjau+mFhXGvj/KyPo9Pp/Rc8Q==",
-          "dev": true,
-          "requires": {
-            "@material/elevation": "^14.0.0"
-          }
-        },
-        "@material/touch-target": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-14.0.0.tgz",
-          "integrity": "sha512-o3kvxmS4HkmZoQTvtzLJrqSG+ezYXkyINm3Uiwio1PTg67pDgK5FRwInkz0VNaWPcw9+5jqjUQGjuZMtjQMq8w==",
-          "dev": true,
-          "requires": {
-            "@material/base": "^14.0.0",
-            "@material/feature-targeting": "^14.0.0",
-            "@material/rtl": "^14.0.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@material/typography": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/typography/-/typography-14.0.0.tgz",
-          "integrity": "sha512-/QtHBYiTR+TPMryM/CT386B2WlAQf/Ae32V324Z7P40gHLKY/YBXx7FDutAWZFeOerq/two4Nd2aAHBcMM2wMw==",
-          "dev": true,
-          "requires": {
-            "@material/feature-targeting": "^14.0.0",
-            "@material/theme": "^14.0.0",
-            "tslib": "^2.1.0"
-          }
-        },
-        "@smui-extra/accordion": {
-          "version": "7.0.0-beta.15",
-          "resolved": "https://registry.npmjs.org/@smui-extra/accordion/-/accordion-7.0.0-beta.15.tgz",
-          "integrity": "sha512-/T5RX6akQRCuo82YMLr3VbmVOdnzO+Vn0zy0PWIOB8YqiSf6ny5T4cY3lENwN9hrAeA5JuMQ8mQbyoa2KWMgbw==",
-          "dev": true,
-          "requires": {
-            "@material/animation": "^14.0.0",
-            "@material/elevation": "^14.0.0",
-            "@material/feature-targeting": "^14.0.0",
-            "@material/ripple": "^14.0.0",
-            "@material/theme": "^14.0.0",
-            "@material/typography": "^14.0.0",
-            "@smui/common": "^7.0.0-beta.15",
-            "@smui/paper": "^7.0.0-beta.15",
-            "@smui/ripple": "^7.0.0-beta.15",
-            "svelte2tsx": "^0.6.21"
-          }
-        },
-        "@smui/common": {
-          "version": "7.0.0-beta.15",
-          "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
-          "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
-          "dev": true,
-          "requires": {
-            "@material/dom": "^14.0.0",
-            "svelte2tsx": "^0.6.21"
-          }
-        },
-        "@smui/fab": {
-          "version": "7.0.0-beta.15",
-          "resolved": "https://registry.npmjs.org/@smui/fab/-/fab-7.0.0-beta.15.tgz",
-          "integrity": "sha512-mO7hscDVA4YslTtB4dxWLNkxl1U/ZKSskglLNKrFWvjCd/MiOSVZSyMODkGnLaeQFMfgGus7moGqS+nY+hvvsQ==",
-          "dev": true,
-          "requires": {
-            "@material/fab": "^14.0.0",
-            "@material/feature-targeting": "^14.0.0",
-            "@smui/common": "^7.0.0-beta.15",
-            "@smui/ripple": "^7.0.0-beta.15",
-            "svelte2tsx": "^0.6.21"
-          }
-        },
-        "@smui/paper": {
-          "version": "7.0.0-beta.15",
-          "resolved": "https://registry.npmjs.org/@smui/paper/-/paper-7.0.0-beta.15.tgz",
-          "integrity": "sha512-qJgu41Gn/5fjhzo9rEhVnYm3U2SL9ECCD1nfmqbRMUzVlaeWrlSwWqJcJSAR6Og2ya8BYBoJetbxUdlLU8X9GA==",
-          "dev": true,
-          "requires": {
-            "@material/elevation": "^14.0.0",
-            "@material/feature-targeting": "^14.0.0",
-            "@material/shape": "^14.0.0",
-            "@material/theme": "^14.0.0",
-            "@material/typography": "^14.0.0",
-            "@smui/common": "^7.0.0-beta.15",
-            "svelte2tsx": "^0.6.21"
-          }
-        },
-        "@smui/ripple": {
-          "version": "7.0.0-beta.15",
-          "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.15.tgz",
-          "integrity": "sha512-l0c94p60gxbsClH0KzA2meJ2IGHc7ZUMyWqODkLNz7ziUYxk3VZvWf/Y7Ca+64IJj0keCGPMpFauFaJO8h3Gtw==",
-          "dev": true,
-          "requires": {
-            "@material/dom": "^14.0.0",
-            "@material/ripple": "^14.0.0",
-            "@smui/common": "^7.0.0-beta.15",
-            "svelte2tsx": "^0.6.21"
-          }
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "ci-info": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
-          "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
-          "dev": true
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "cross-spawn": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          }
-        },
-        "fs-extra": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "patch-package": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-7.0.2.tgz",
-          "integrity": "sha512-PMYfL8LXxGIRmxXLqlEaBxzKPu7/SdP13ld6GSfAUJUZRmBDPp8chZs0dpzaAFn9TSPnFiMwkC6PJt6pBiAl8Q==",
-          "dev": true,
-          "requires": {
-            "@yarnpkg/lockfile": "^1.1.0",
-            "chalk": "^4.1.2",
-            "ci-info": "^3.7.0",
-            "cross-spawn": "^7.0.3",
-            "find-yarn-workspace-root": "^2.0.0",
-            "fs-extra": "^9.0.0",
-            "klaw-sync": "^6.0.0",
-            "minimist": "^1.2.6",
-            "open": "^7.4.2",
-            "rimraf": "^2.6.3",
-            "semver": "^7.5.3",
-            "slash": "^2.0.0",
-            "tmp": "^0.0.33",
-            "yaml": "^2.2.2"
-          }
-        },
-        "path-key": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "svelte2tsx": {
-          "version": "0.6.23",
-          "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.23.tgz",
-          "integrity": "sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==",
-          "dev": true,
-          "requires": {
-            "dedent-js": "^1.0.1",
-            "pascal-case": "^3.1.1"
-          }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-          "dev": true
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
       }
     },
     "svelte-material-ui": {
@@ -16068,12 +15947,6 @@
         }
       }
     },
-    "svelte-portal": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/svelte-portal/-/svelte-portal-2.2.0.tgz",
-      "integrity": "sha512-jhtZWtD6cUE2nMw46dJ5VXWYiqnER+JH+V/BmNBQ5fNP/YdsJCpJi+DemUy9msklqGb0f+wLhJPBtKHLWQvzjg==",
-      "dev": true
-    },
     "svelte-preprocess": {
       "version": "4.10.7",
       "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz",
@@ -16198,8 +16071,7 @@
     "typescript": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
     },
     "universalify": {
       "version": "0.1.2",
@@ -16207,62 +16079,10 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
-    "uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "validate.io-array": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
-      "integrity": "sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg==",
-      "dev": true
-    },
-    "validate.io-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
-      "integrity": "sha512-LlFybRJEriSuBnUhQyG5bwglhh50EpTL2ul23MPIuR1odjO7XaMLFV8vHGwp7AZciFxtYOeiSCT5st+XSPONiQ==",
-      "dev": true
-    },
-    "validate.io-integer": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
-      "integrity": "sha512-22izsYSLojN/P6bppBqhgUDjCkr5RY2jd+N2a3DCAUey8ydvrZ/OkGvFPR7qfOpwR2LC5p4Ngzxz36g5Vgr/hQ==",
-      "dev": true,
-      "requires": {
-        "validate.io-number": "^1.0.3"
-      }
-    },
-    "validate.io-integer-array": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
-      "integrity": "sha512-mTrMk/1ytQHtCY0oNO3dztafHYyGU88KL+jRxWuzfOmQb+4qqnWmI+gykvGp8usKZOM0H7keJHEbRaFiYA0VrA==",
-      "dev": true,
-      "requires": {
-        "validate.io-array": "^1.0.3",
-        "validate.io-integer": "^1.0.4"
-      }
-    },
-    "validate.io-number": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
-      "integrity": "sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg==",
-      "dev": true
-    },
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
-    },
-    "whatwg-fetch": {
-      "version": "3.6.17",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.17.tgz",
-      "integrity": "sha512-c4ghIvG6th0eudYwKZY5keb81wtFz9/WeAHAoy8+r18kcWlitUIrmGFQ2rWEl4UCKUilD3zCLHOIPheHx5ypRQ==",
       "dev": true
     },
     "whatwg-url": {
@@ -16283,6 +16103,13 @@
       "requires": {
         "isexe": "^2.0.0"
       }
+    },
+    "workerpool": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+      "dev": true,
+      "peer": true
     },
     "wrap-ansi": {
       "version": "7.0.0",
@@ -16331,7 +16158,8 @@
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "y18n": {
       "version": "5.0.8",
@@ -16343,12 +16171,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
-    "yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
       "dev": true
     },
     "yargs": {
@@ -16385,11 +16207,31 @@
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true
     },
+    "yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      }
+    },
     "yn": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
       "integrity": "sha512-uTv8J/wiWTgUTg+9vLTi//leUl5vDQS6uii/emeTb2ssY7vl6QWf2fFbIIGjnhjvbdKlU0ed7QPgY1htTC86jQ==",
       "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "peer": true
     },
     "zrender": {
       "version": "5.4.4",

--- a/src/routers/Insights/dashboard/package.json
+++ b/src/routers/Insights/dashboard/package.json
@@ -46,7 +46,6 @@
     "svelte-check": "^2.0.0",
     "svelte-echarts": "^0.0.5",
     "svelte-file-dropzone": "^1.0.0",
-    "svelte-jsonschema-form": "github:webgme/svelte-jsonschema-form#v0.6.0",
     "svelte-preprocess": "^4.0.0",
     "ts-mocha": "^10.0.0",
     "tslib": "^2.0.0",

--- a/src/routers/Search/dashboard/package-lock.json
+++ b/src/routers/Search/dashboard/package-lock.json
@@ -46,7 +46,7 @@
         "svelte": "^3.0.0",
         "svelte-check": "^2.0.0",
         "svelte-file-dropzone": "^1.0.0",
-        "svelte-jsonschema-form": "github:webgme/svelte-jsonschema-form#v0.6.0",
+        "svelte-jsonschema-form": "github:webgme/svelte-jsonschema-form#v0.6.4",
         "svelte-preprocess": "^4.0.0",
         "ts-mocha": "^10.0.0",
         "tslib": "^2.0.0",
@@ -150,39 +150,6 @@
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
-    },
-    "node_modules/@json-schema-spec/json-pointer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@json-schema-spec/json-pointer/-/json-pointer-0.1.2.tgz",
-      "integrity": "sha512-BYY7IavBjwsWWSmVcMz2A9mKiDD9RvacnsItgmy1xV8cmgbtxFfKmKMtkVpD7pYtkx4mIW4800yZBXueVFIWPw==",
-      "dev": true
-    },
-    "node_modules/@json-schema-tools/dereferencer": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/dereferencer/-/dereferencer-1.6.1.tgz",
-      "integrity": "sha512-+h+K/H3pWoJVztTuz1ycTUc0ai/xH5eLZLurE4jQpqYwPcPvsXtFfbRxDhvxrrpjjg4PV3HmEjjORIEQPO4Dmw==",
-      "dev": true,
-      "dependencies": {
-        "@json-schema-tools/reference-resolver": "^1.2.5",
-        "@json-schema-tools/traverse": "^1.10.0",
-        "fast-safe-stringify": "^2.1.1"
-      }
-    },
-    "node_modules/@json-schema-tools/reference-resolver": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/reference-resolver/-/reference-resolver-1.2.5.tgz",
-      "integrity": "sha512-xNQgX/ABnwvbIeexL5Czv08lXjHAL80HEUogza7E19eIL/EXD8HM4FvxG1JuTGyi5fA+sSP64C9pabELizcBBw==",
-      "dev": true,
-      "dependencies": {
-        "@json-schema-spec/json-pointer": "^0.1.2",
-        "isomorphic-fetch": "^3.0.0"
-      }
-    },
-    "node_modules/@json-schema-tools/traverse": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/traverse/-/traverse-1.10.1.tgz",
-      "integrity": "sha512-vYY5EIxCPzEXEWL/vTjdHy4g92tv1ApUQCjPJsj9gEoXLNNVwJlwwgRZisuvgFBZ3zeLzQygrbehERSpYdmFZA==",
       "dev": true
     },
     "node_modules/@material/animation": {
@@ -2651,6 +2618,20 @@
         "typescript": "^4.9.4 || ^5.0.0"
       }
     },
+    "node_modules/@smui/card/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@smui/checkbox": {
       "version": "7.0.0-beta.15",
       "resolved": "https://registry.npmjs.org/@smui/checkbox/-/checkbox-7.0.0-beta.15.tgz",
@@ -2810,6 +2791,20 @@
         "typescript": "^4.9.4 || ^5.0.0"
       }
     },
+    "node_modules/@smui/checkbox/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@smui/chips": {
       "version": "7.0.0-beta.9",
       "resolved": "https://registry.npmjs.org/@smui/chips/-/chips-7.0.0-beta.9.tgz",
@@ -2930,6 +2925,20 @@
       "peerDependencies": {
         "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0",
         "typescript": "^4.9.4 || ^5.0.0"
+      }
+    },
+    "node_modules/@smui/chips/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@smui/circular-progress": {
@@ -3239,6 +3248,20 @@
         "typescript": "^4.9.4 || ^5.0.0"
       }
     },
+    "node_modules/@smui/dialog/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@smui/drawer": {
       "version": "7.0.0-beta.9",
       "resolved": "https://registry.npmjs.org/@smui/drawer/-/drawer-7.0.0-beta.9.tgz",
@@ -3292,6 +3315,20 @@
       "peerDependencies": {
         "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0",
         "typescript": "^4.9.4 || ^5.0.0"
+      }
+    },
+    "node_modules/@smui/drawer/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@smui/fab": {
@@ -3390,6 +3427,20 @@
       "peerDependencies": {
         "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0",
         "typescript": "^4.9.4 || ^5.0.0"
+      }
+    },
+    "node_modules/@smui/form-field/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@smui/icon-button": {
@@ -3565,6 +3616,20 @@
       "peerDependencies": {
         "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0",
         "typescript": "^4.9.4 || ^5.0.0"
+      }
+    },
+    "node_modules/@smui/icon-button/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@smui/image-list": {
@@ -3777,6 +3842,20 @@
       "peerDependencies": {
         "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0",
         "typescript": "^4.9.4 || ^5.0.0"
+      }
+    },
+    "node_modules/@smui/list/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@smui/menu": {
@@ -4010,6 +4089,20 @@
         "typescript": "^4.9.4 || ^5.0.0"
       }
     },
+    "node_modules/@smui/menu/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@smui/notched-outline": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/@smui/notched-outline/-/notched-outline-6.1.4.tgz",
@@ -4153,6 +4246,20 @@
       "peerDependencies": {
         "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0",
         "typescript": "^4.9.4 || ^5.0.0"
+      }
+    },
+    "node_modules/@smui/radio/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@smui/ripple": {
@@ -4531,6 +4638,20 @@
         "typescript": "^4.9.4 || ^5.0.0"
       }
     },
+    "node_modules/@smui/select/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@smui/slider": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@smui/slider/-/slider-6.0.0.tgz",
@@ -4770,6 +4891,20 @@
       "peerDependencies": {
         "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0",
         "typescript": "^4.9.4 || ^5.0.0"
+      }
+    },
+    "node_modules/@smui/snackbar/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@smui/switch": {
@@ -5058,6 +5193,20 @@
         "typescript": "^4.9.4 || ^5.0.0"
       }
     },
+    "node_modules/@smui/textfield/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@smui/tooltip": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@smui/tooltip/-/tooltip-6.0.0.tgz",
@@ -5121,6 +5270,20 @@
       "peerDependencies": {
         "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0",
         "typescript": "^4.9.4 || ^5.0.0"
+      }
+    },
+    "node_modules/@smui/top-app-bar/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@smui/touch-target": {
@@ -5251,6 +5414,16 @@
         }
       }
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -5284,6 +5457,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/arrify": {
       "version": "1.0.1",
@@ -5340,6 +5520,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -5374,6 +5561,19 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/carbon-components-svelte": {
@@ -5431,6 +5631,18 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
@@ -5497,9 +5709,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.0.tgz",
-      "integrity": "sha512-rd4rYZNlF3WuoYuRIDEmbR/ga9CeuWX9U05umAvgrrZoHY4Z++cp/xwPQMvUpBB4Ag6J8KfD80G0zwCyaSxDww==",
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.2.tgz",
+      "integrity": "sha512-XeBzWI6QL3nJQiHmdzbAOiMYqjrb7hwU7A39Qhvd/POSa/t9E1AeZyEZx3fNvp/vtM8zXwhoL0FsiS0hD0pruQ==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -5546,6 +5758,19 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent-js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
@@ -5567,6 +5792,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/emoji-regex": {
@@ -5626,12 +5861,6 @@
       "engines": {
         "node": ">=8.6.0"
       }
-    },
-    "node_modules/fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -5703,6 +5932,16 @@
       "dev": true,
       "dependencies": {
         "micromatch": "^4.0.2"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "flat": "cli.js"
       }
     },
     "node_modules/flatpickr": {
@@ -5833,6 +6072,16 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -5982,6 +6231,16 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-reference": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -5989,6 +6248,19 @@
       "dev": true,
       "dependencies": {
         "@types/estree": "*"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-wsl": {
@@ -6008,16 +6280,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
-    },
-    "node_modules/isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
     },
     "node_modules/jest-worker": {
       "version": "26.6.2",
@@ -6059,6 +6321,19 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/json-schema-compare": {
       "version": "0.2.2",
@@ -6177,6 +6452,99 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/log-symbols/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-symbols/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
@@ -6304,6 +6672,247 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/mocha": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "5.0.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.3",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "workerpool": "6.2.1",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/mocha/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mocha/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mocha/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mocha/node_modules/serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/mocha/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -6318,6 +6927,26 @@
       "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/nice-try": {
@@ -6552,9 +7181,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -7161,6 +7790,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -7189,7 +7831,6 @@
       "version": "3.59.2",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.59.2.tgz",
       "integrity": "sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -7226,8 +7867,13 @@
       }
     },
     "node_modules/svelte-jsonschema-form": {
-      "version": "0.6.0",
-      "resolved": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#d3247a9066399acc032c625a2af4cb99682745fa",
+      "version": "0.6.4",
+      "resolved": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#0999ae10bd9907e6867acaf38cfb76011ee9be2e",
+      "bundleDependencies": [
+        "@json-schema-tools/dereferencer",
+        "@smui/select",
+        "svelte-portal"
+      ],
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -7254,29 +7900,71 @@
         "svelte": "^3.50 || ^4"
       }
     },
+    "node_modules/svelte-jsonschema-form/node_modules/@json-schema-spec/json-pointer": {
+      "version": "0.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@json-schema-tools/dereferencer": {
+      "version": "1.6.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@json-schema-tools/reference-resolver": "^1.2.5",
+        "@json-schema-tools/traverse": "^1.10.0",
+        "fast-safe-stringify": "^2.1.1"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@json-schema-tools/reference-resolver": {
+      "version": "1.2.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@json-schema-spec/json-pointer": "^0.1.2",
+        "isomorphic-fetch": "^3.0.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@json-schema-tools/traverse": {
+      "version": "1.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/svelte-jsonschema-form/node_modules/@material/animation": {
       "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-14.0.0.tgz",
-      "integrity": "sha512-VlYSfUaIj/BBVtRZI8Gv0VvzikFf+XgK0Zdgsok5c1v5DDnNz5tpB8mnGrveWz0rHbp1X4+CWLKrTwNmjrw3Xw==",
       "dev": true,
+      "inBundle": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/svelte-jsonschema-form/node_modules/@material/base": {
       "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/base/-/base-14.0.0.tgz",
-      "integrity": "sha512-Ou7vS7n1H4Y10MUZyYAbt6H0t67c6urxoCgeVT7M38aQlaNUwFMODp7KT/myjYz2YULfhu3PtfSV3Sltgac9mA==",
       "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/density": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/svelte-jsonschema-form/node_modules/@material/dom": {
       "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-14.0.0.tgz",
-      "integrity": "sha512-8t88XyacclTj8qsIw9q0vEj4PI2KVncLoIsIMzwuMx49P2FZg6TsLjor262MI3Qs00UWAifuLMrhnOnfyrbe7Q==",
       "dev": true,
+      "inBundle": true,
+      "license": "MIT",
       "dependencies": {
         "@material/feature-targeting": "^14.0.0",
         "tslib": "^2.1.0"
@@ -7284,9 +7972,9 @@
     },
     "node_modules/svelte-jsonschema-form/node_modules/@material/elevation": {
       "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-14.0.0.tgz",
-      "integrity": "sha512-Di3tkxTpXwvf1GJUmaC8rd+zVh5dB2SWMBGagL4+kT8UmjSISif/OPRGuGnXs3QhF6nmEjkdC0ijdZLcYQkepw==",
       "dev": true,
+      "inBundle": true,
+      "license": "MIT",
       "dependencies": {
         "@material/animation": "^14.0.0",
         "@material/base": "^14.0.0",
@@ -7319,18 +8007,114 @@
     },
     "node_modules/svelte-jsonschema-form/node_modules/@material/feature-targeting": {
       "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0.tgz",
-      "integrity": "sha512-a5WGgHEq5lJeeNL5yevtgoZjBjXWy6+klfVWQEh8oyix/rMJygGgO7gEc52uv8fB8uAIoYEB3iBMOv8jRq8FeA==",
       "dev": true,
+      "inBundle": true,
+      "license": "MIT",
       "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/floating-label": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "^14.0.0",
+        "@material/base": "^14.0.0",
+        "@material/dom": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "@material/typography": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/line-ripple": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "^14.0.0",
+        "@material/base": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/list": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "^14.0.0",
+        "@material/density": "^14.0.0",
+        "@material/dom": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/ripple": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/shape": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "@material/typography": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/menu": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "^14.0.0",
+        "@material/dom": "^14.0.0",
+        "@material/elevation": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/list": "^14.0.0",
+        "@material/menu-surface": "^14.0.0",
+        "@material/ripple": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/menu-surface": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "^14.0.0",
+        "@material/base": "^14.0.0",
+        "@material/elevation": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/shape": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/notched-outline": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/floating-label": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/shape": "^14.0.0",
+        "@material/theme": "^14.0.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/svelte-jsonschema-form/node_modules/@material/ripple": {
       "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-14.0.0.tgz",
-      "integrity": "sha512-9XoGBFd5JhFgELgW7pqtiLy+CnCIcV2s9cQ2BWbOQeA8faX9UZIDUx/g76nHLZ7UzKFtsULJxZTwORmsEt2zvw==",
       "dev": true,
+      "inBundle": true,
+      "license": "MIT",
       "dependencies": {
         "@material/animation": "^14.0.0",
         "@material/base": "^14.0.0",
@@ -7343,19 +8127,46 @@
     },
     "node_modules/svelte-jsonschema-form/node_modules/@material/rtl": {
       "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-14.0.0.tgz",
-      "integrity": "sha512-xl6OZYyRjuiW2hmbjV2omMV8sQtfmKAjeWnD1RMiAPLCTyOW9Lh/PYYnXjxUrNa0cRwIIbOn5J7OYXokja8puA==",
       "dev": true,
+      "inBundle": true,
+      "license": "MIT",
       "dependencies": {
         "@material/theme": "^14.0.0",
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/select": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "^14.0.0",
+        "@material/base": "^14.0.0",
+        "@material/density": "^14.0.0",
+        "@material/dom": "^14.0.0",
+        "@material/elevation": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/floating-label": "^14.0.0",
+        "@material/line-ripple": "^14.0.0",
+        "@material/list": "^14.0.0",
+        "@material/menu": "^14.0.0",
+        "@material/menu-surface": "^14.0.0",
+        "@material/notched-outline": "^14.0.0",
+        "@material/ripple": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/shape": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "@material/tokens": "^14.0.0",
+        "@material/typography": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/svelte-jsonschema-form/node_modules/@material/shape": {
       "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/shape/-/shape-14.0.0.tgz",
-      "integrity": "sha512-o0mJB0+feOv473KckI8gFnUo8IQAaEA6ynXzw3VIYFjPi48pJwrxa0mZcJP/OoTXrCbDzDeFJfDPXEmRioBb9A==",
       "dev": true,
+      "inBundle": true,
+      "license": "MIT",
       "dependencies": {
         "@material/feature-targeting": "^14.0.0",
         "@material/rtl": "^14.0.0",
@@ -7365,9 +8176,9 @@
     },
     "node_modules/svelte-jsonschema-form/node_modules/@material/theme": {
       "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0.tgz",
-      "integrity": "sha512-6/SENWNIFuXzeHMPHrYwbsXKgkvCtWuzzQ3cUu4UEt3KcQ5YpViazIM6h8ByYKZP8A9d8QpkJ0WGX5btGDcVoA==",
       "dev": true,
+      "inBundle": true,
+      "license": "MIT",
       "dependencies": {
         "@material/feature-targeting": "^14.0.0",
         "tslib": "^2.1.0"
@@ -7375,9 +8186,9 @@
     },
     "node_modules/svelte-jsonschema-form/node_modules/@material/tokens": {
       "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-14.0.0.tgz",
-      "integrity": "sha512-SXgB9VwsKW4DFkHmJfDIS0x0cGdMWC1D06m6z/WQQ5P5j6/m0pKrbHVlrLzXcRjau+mFhXGvj/KyPo9Pp/Rc8Q==",
       "dev": true,
+      "inBundle": true,
+      "license": "MIT",
       "dependencies": {
         "@material/elevation": "^14.0.0"
       }
@@ -7396,9 +8207,9 @@
     },
     "node_modules/svelte-jsonschema-form/node_modules/@material/typography": {
       "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-14.0.0.tgz",
-      "integrity": "sha512-/QtHBYiTR+TPMryM/CT386B2WlAQf/Ae32V324Z7P40gHLKY/YBXx7FDutAWZFeOerq/two4Nd2aAHBcMM2wMw==",
       "dev": true,
+      "inBundle": true,
+      "license": "MIT",
       "dependencies": {
         "@material/feature-targeting": "^14.0.0",
         "@material/theme": "^14.0.0",
@@ -7424,13 +8235,13 @@
       }
     },
     "node_modules/svelte-jsonschema-form/node_modules/@smui/common": {
-      "version": "7.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
-      "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
+      "version": "7.0.0-beta.14",
       "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@material/dom": "^14.0.0",
-        "svelte2tsx": "^0.6.21"
+        "svelte2tsx": "^0.6.15"
       }
     },
     "node_modules/svelte-jsonschema-form/node_modules/@smui/fab": {
@@ -7444,6 +8255,80 @@
         "@smui/common": "^7.0.0-beta.15",
         "@smui/ripple": "^7.0.0-beta.15",
         "svelte2tsx": "^0.6.21"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@smui/floating-label": {
+      "version": "7.0.0-beta.14",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/floating-label": "^14.0.0",
+        "@smui/common": "^7.0.0-beta.14",
+        "svelte2tsx": "^0.6.15"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@smui/line-ripple": {
+      "version": "7.0.0-beta.14",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/line-ripple": "^14.0.0",
+        "@smui/common": "^7.0.0-beta.14",
+        "svelte2tsx": "^0.6.15"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@smui/list": {
+      "version": "7.0.0-beta.14",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/dom": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/list": "^14.0.0",
+        "@smui/common": "^7.0.0-beta.14",
+        "@smui/ripple": "^7.0.0-beta.14",
+        "svelte2tsx": "^0.6.15"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@smui/menu": {
+      "version": "7.0.0-beta.14",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/dom": "^14.0.0",
+        "@material/menu": "^14.0.0",
+        "@smui/common": "^7.0.0-beta.14",
+        "@smui/list": "^7.0.0-beta.14",
+        "@smui/menu-surface": "^7.0.0-beta.14",
+        "svelte2tsx": "^0.6.15"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@smui/menu-surface": {
+      "version": "7.0.0-beta.14",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/animation": "^14.0.0",
+        "@material/menu-surface": "^14.0.0",
+        "@smui/common": "^7.0.0-beta.14",
+        "svelte2tsx": "^0.6.15"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@smui/notched-outline": {
+      "version": "7.0.0-beta.14",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/notched-outline": "^14.0.0",
+        "@smui/common": "^7.0.0-beta.14",
+        "@smui/floating-label": "^7.0.0-beta.14",
+        "svelte2tsx": "^0.6.15"
       }
     },
     "node_modules/svelte-jsonschema-form/node_modules/@smui/paper": {
@@ -7462,15 +8347,37 @@
       }
     },
     "node_modules/svelte-jsonschema-form/node_modules/@smui/ripple": {
-      "version": "7.0.0-beta.15",
-      "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.15.tgz",
-      "integrity": "sha512-l0c94p60gxbsClH0KzA2meJ2IGHc7ZUMyWqODkLNz7ziUYxk3VZvWf/Y7Ca+64IJj0keCGPMpFauFaJO8h3Gtw==",
+      "version": "7.0.0-beta.14",
       "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@material/dom": "^14.0.0",
         "@material/ripple": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.15",
-        "svelte2tsx": "^0.6.21"
+        "@smui/common": "^7.0.0-beta.14",
+        "svelte2tsx": "^0.6.15"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@smui/select": {
+      "version": "7.0.0-beta.14",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/feature-targeting": "^14.0.0",
+        "@material/ripple": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/select": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "@smui/common": "^7.0.0-beta.14",
+        "@smui/floating-label": "^7.0.0-beta.14",
+        "@smui/line-ripple": "^7.0.0-beta.14",
+        "@smui/list": "^7.0.0-beta.14",
+        "@smui/menu": "^7.0.0-beta.14",
+        "@smui/menu-surface": "^7.0.0-beta.14",
+        "@smui/notched-outline": "^7.0.0-beta.14",
+        "@smui/ripple": "^7.0.0-beta.14",
+        "svelte2tsx": "^0.6.15"
       }
     },
     "node_modules/svelte-jsonschema-form/node_modules/ansi-styles": {
@@ -7505,9 +8412,9 @@
       }
     },
     "node_modules/svelte-jsonschema-form/node_modules/ci-info": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
-      "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
       "dev": true,
       "funding": [
         {
@@ -7551,6 +8458,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/svelte-jsonschema-form/node_modules/dedent-js": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/svelte-jsonschema-form/node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -7575,6 +8494,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/svelte-jsonschema-form/node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
     "node_modules/svelte-jsonschema-form/node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -7585,6 +8514,55 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/lower-case": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/no-case": {
+      "version": "3.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/node-fetch": {
+      "version": "2.6.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/pascal-case": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/svelte-jsonschema-form/node_modules/patch-package": {
@@ -7673,11 +8651,17 @@
         "node": ">=8"
       }
     },
-    "node_modules/svelte-jsonschema-form/node_modules/svelte2tsx": {
-      "version": "0.6.22",
-      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.22.tgz",
-      "integrity": "sha512-eFCfz0juaWeanbwGeQV21kPMwH3LKhfrUYRy1PqRmlieuHvJs8VeK7CaoHJdpBZWCXba2cltHVdywJmwOGhbww==",
+    "node_modules/svelte-jsonschema-form/node_modules/svelte-portal": {
+      "version": "2.2.0",
       "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/svelte2tsx": {
+      "version": "0.6.19",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
       "dependencies": {
         "dedent-js": "^1.0.1",
         "pascal-case": "^3.1.1"
@@ -7687,6 +8671,33 @@
         "typescript": "^4.9.4 || ^5.0.0"
       }
     },
+    "node_modules/svelte-jsonschema-form/node_modules/tr46": {
+      "version": "0.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/tslib": {
+      "version": "2.5.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD"
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "inBundle": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/svelte-jsonschema-form/node_modules/universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
@@ -7694,6 +8705,28 @@
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/whatwg-fetch": {
+      "version": "3.6.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/svelte-jsonschema-form/node_modules/which": {
@@ -8110,12 +9143,6 @@
         "svelte2tsx": "^0.5.12"
       }
     },
-    "node_modules/svelte-portal": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/svelte-portal/-/svelte-portal-2.2.0.tgz",
-      "integrity": "sha512-jhtZWtD6cUE2nMw46dJ5VXWYiqnER+JH+V/BmNBQ5fNP/YdsJCpJi+DemUy9msklqGb0f+wLhJPBtKHLWQvzjg==",
-      "dev": true
-    },
     "node_modules/svelte-preprocess": {
       "version": "4.10.7",
       "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz",
@@ -8333,7 +9360,6 @@
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8403,12 +9429,6 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true
     },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.17",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.17.tgz",
-      "integrity": "sha512-c4ghIvG6th0eudYwKZY5keb81wtFz9/WeAHAoy8+r18kcWlitUIrmGFQ2rWEl4UCKUilD3zCLHOIPheHx5ypRQ==",
-      "dev": true
-    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -8430,6 +9450,13 @@
       "bin": {
         "which": "bin/which"
       }
+    },
+    "node_modules/workerpool": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -8524,9 +9551,9 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.3.tgz",
+      "integrity": "sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==",
       "dev": true,
       "engines": {
         "node": ">= 14"
@@ -8559,6 +9586,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yargs/node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -8580,6 +9623,19 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   },
@@ -8666,39 +9722,6 @@
           "dev": true
         }
       }
-    },
-    "@json-schema-spec/json-pointer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@json-schema-spec/json-pointer/-/json-pointer-0.1.2.tgz",
-      "integrity": "sha512-BYY7IavBjwsWWSmVcMz2A9mKiDD9RvacnsItgmy1xV8cmgbtxFfKmKMtkVpD7pYtkx4mIW4800yZBXueVFIWPw==",
-      "dev": true
-    },
-    "@json-schema-tools/dereferencer": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/dereferencer/-/dereferencer-1.6.1.tgz",
-      "integrity": "sha512-+h+K/H3pWoJVztTuz1ycTUc0ai/xH5eLZLurE4jQpqYwPcPvsXtFfbRxDhvxrrpjjg4PV3HmEjjORIEQPO4Dmw==",
-      "dev": true,
-      "requires": {
-        "@json-schema-tools/reference-resolver": "^1.2.5",
-        "@json-schema-tools/traverse": "^1.10.0",
-        "fast-safe-stringify": "^2.1.1"
-      }
-    },
-    "@json-schema-tools/reference-resolver": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/reference-resolver/-/reference-resolver-1.2.5.tgz",
-      "integrity": "sha512-xNQgX/ABnwvbIeexL5Czv08lXjHAL80HEUogza7E19eIL/EXD8HM4FvxG1JuTGyi5fA+sSP64C9pabELizcBBw==",
-      "dev": true,
-      "requires": {
-        "@json-schema-spec/json-pointer": "^0.1.2",
-        "isomorphic-fetch": "^3.0.0"
-      }
-    },
-    "@json-schema-tools/traverse": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/traverse/-/traverse-1.10.1.tgz",
-      "integrity": "sha512-vYY5EIxCPzEXEWL/vTjdHy4g92tv1ApUQCjPJsj9gEoXLNNVwJlwwgRZisuvgFBZ3zeLzQygrbehERSpYdmFZA==",
-      "dev": true
     },
     "@material/animation": {
       "version": "13.0.0",
@@ -11143,6 +12166,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -11300,6 +12330,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -11420,6 +12457,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -11729,6 +12773,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -11782,6 +12833,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -11878,6 +12936,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -12051,6 +13116,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -12261,6 +13333,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -12479,6 +13558,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -12633,6 +13719,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -13007,6 +14100,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -13246,6 +14346,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -13530,6 +14637,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -13593,6 +14707,13 @@
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -13703,6 +14824,13 @@
         "ajv": "^8.0.0"
       }
     },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true,
+      "peer": true
+    },
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -13727,6 +14855,13 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "peer": true
     },
     "arrify": {
       "version": "1.0.1",
@@ -13771,6 +14906,13 @@
         "fill-range": "^7.0.1"
       }
     },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "peer": true
+    },
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -13794,6 +14936,13 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
+    },
+    "camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "peer": true
     },
     "carbon-components-svelte": {
       "version": "0.67.4",
@@ -13836,6 +14985,18 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
+    },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
     },
     "color-convert": {
       "version": "1.9.3",
@@ -13899,9 +15060,9 @@
       "integrity": "sha512-pMD+MVR538ipqkG5JXeOEbKWS5um1H4LUUccUQG68qpeqBYbzYy79Gh55jkd2TtPdRfUaLWdv6LPP//5Zt0aPQ=="
     },
     "core-js": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.0.tgz",
-      "integrity": "sha512-rd4rYZNlF3WuoYuRIDEmbR/ga9CeuWX9U05umAvgrrZoHY4Z++cp/xwPQMvUpBB4Ag6J8KfD80G0zwCyaSxDww==",
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.2.tgz",
+      "integrity": "sha512-XeBzWI6QL3nJQiHmdzbAOiMYqjrb7hwU7A39Qhvd/POSa/t9E1AeZyEZx3fNvp/vtM8zXwhoL0FsiS0hD0pruQ==",
       "dev": true
     },
     "cross-spawn": {
@@ -13934,6 +15095,13 @@
         }
       }
     },
+    "decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "peer": true
+    },
     "dedent-js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
@@ -13950,6 +15118,13 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
       "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
       "dev": true
+    },
+    "diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "peer": true
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -13999,12 +15174,6 @@
         "merge2": "^1.3.0",
         "micromatch": "^4.0.4"
       }
-    },
-    "fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true
     },
     "fastq": {
       "version": "1.13.0",
@@ -14062,6 +15231,13 @@
       "requires": {
         "micromatch": "^4.0.2"
       }
+    },
+    "flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "peer": true
     },
     "flatpickr": {
       "version": "4.6.9",
@@ -14158,6 +15334,13 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "peer": true
     },
     "https-proxy-agent": {
       "version": "5.0.1",
@@ -14267,6 +15450,13 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "peer": true
+    },
     "is-reference": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -14275,6 +15465,13 @@
       "requires": {
         "@types/estree": "*"
       }
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "peer": true
     },
     "is-wsl": {
       "version": "2.2.0",
@@ -14290,16 +15487,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
-    },
-    "isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
     },
     "jest-worker": {
       "version": "26.6.2",
@@ -14334,6 +15521,16 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "argparse": "^2.0.1"
+      }
     },
     "json-schema-compare": {
       "version": "0.2.2",
@@ -14431,6 +15628,74 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "peer": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "peer": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "lower-case": {
       "version": "2.0.2",
@@ -14533,6 +15798,185 @@
         "minimist": "^1.2.6"
       }
     },
+    "mocha": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "5.0.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.3",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "workerpool": "6.2.1",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true,
+          "peer": true
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          },
+          "dependencies": {
+            "minimatch": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+              "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            }
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "peer": true
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+              "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+              "dev": true,
+              "peer": true,
+              "requires": {
+                "balanced-match": "^1.0.0"
+              }
+            }
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "serialize-javascript": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+          "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
     "mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -14542,6 +15986,20 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
       "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw=="
+    },
+    "ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "peer": true
+    },
+    "nanoid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+      "dev": true,
+      "peer": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -14713,9 +16171,9 @@
       }
     },
     "punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true
     },
     "queue-microtask": {
@@ -15148,6 +16606,13 @@
         "min-indent": "^1.0.0"
       }
     },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "peer": true
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -15166,8 +16631,7 @@
     "svelte": {
       "version": "3.59.2",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.59.2.tgz",
-      "integrity": "sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==",
-      "dev": true
+      "integrity": "sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA=="
     },
     "svelte-check": {
       "version": "2.8.0",
@@ -15195,9 +16659,9 @@
       }
     },
     "svelte-jsonschema-form": {
-      "version": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#d3247a9066399acc032c625a2af4cb99682745fa",
+      "version": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#0999ae10bd9907e6867acaf38cfb76011ee9be2e",
       "dev": true,
-      "from": "svelte-jsonschema-form@github:webgme/svelte-jsonschema-form#v0.6.0",
+      "from": "svelte-jsonschema-form@github:webgme/svelte-jsonschema-form#v0.6.4",
       "requires": {
         "@json-schema-tools/dereferencer": "^1.6.1",
         "@json-schema-tools/traverse": "^1.10.1",
@@ -15218,10 +16682,38 @@
         "svelte-portal": "^2.2.0"
       },
       "dependencies": {
+        "@json-schema-spec/json-pointer": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "@json-schema-tools/dereferencer": {
+          "version": "1.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@json-schema-tools/reference-resolver": "^1.2.5",
+            "@json-schema-tools/traverse": "^1.10.0",
+            "fast-safe-stringify": "^2.1.1"
+          }
+        },
+        "@json-schema-tools/reference-resolver": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@json-schema-spec/json-pointer": "^0.1.2",
+            "isomorphic-fetch": "^3.0.0"
+          }
+        },
+        "@json-schema-tools/traverse": {
+          "version": "1.10.1",
+          "bundled": true,
+          "dev": true
+        },
         "@material/animation": {
           "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/animation/-/animation-14.0.0.tgz",
-          "integrity": "sha512-VlYSfUaIj/BBVtRZI8Gv0VvzikFf+XgK0Zdgsok5c1v5DDnNz5tpB8mnGrveWz0rHbp1X4+CWLKrTwNmjrw3Xw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "tslib": "^2.1.0"
@@ -15229,8 +16721,15 @@
         },
         "@material/base": {
           "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/base/-/base-14.0.0.tgz",
-          "integrity": "sha512-Ou7vS7n1H4Y10MUZyYAbt6H0t67c6urxoCgeVT7M38aQlaNUwFMODp7KT/myjYz2YULfhu3PtfSV3Sltgac9mA==",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/density": {
+          "version": "14.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "tslib": "^2.1.0"
@@ -15238,8 +16737,7 @@
         },
         "@material/dom": {
           "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/dom/-/dom-14.0.0.tgz",
-          "integrity": "sha512-8t88XyacclTj8qsIw9q0vEj4PI2KVncLoIsIMzwuMx49P2FZg6TsLjor262MI3Qs00UWAifuLMrhnOnfyrbe7Q==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@material/feature-targeting": "^14.0.0",
@@ -15248,8 +16746,7 @@
         },
         "@material/elevation": {
           "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-14.0.0.tgz",
-          "integrity": "sha512-Di3tkxTpXwvf1GJUmaC8rd+zVh5dB2SWMBGagL4+kT8UmjSISif/OPRGuGnXs3QhF6nmEjkdC0ijdZLcYQkepw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@material/animation": "^14.0.0",
@@ -15283,17 +16780,105 @@
         },
         "@material/feature-targeting": {
           "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0.tgz",
-          "integrity": "sha512-a5WGgHEq5lJeeNL5yevtgoZjBjXWy6+klfVWQEh8oyix/rMJygGgO7gEc52uv8fB8uAIoYEB3iBMOv8jRq8FeA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "tslib": "^2.1.0"
           }
         },
+        "@material/floating-label": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/animation": "^14.0.0",
+            "@material/base": "^14.0.0",
+            "@material/dom": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "@material/typography": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/line-ripple": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/animation": "^14.0.0",
+            "@material/base": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/list": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/base": "^14.0.0",
+            "@material/density": "^14.0.0",
+            "@material/dom": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/ripple": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "@material/shape": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "@material/typography": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/menu": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/base": "^14.0.0",
+            "@material/dom": "^14.0.0",
+            "@material/elevation": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/list": "^14.0.0",
+            "@material/menu-surface": "^14.0.0",
+            "@material/ripple": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/menu-surface": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/animation": "^14.0.0",
+            "@material/base": "^14.0.0",
+            "@material/elevation": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "@material/shape": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/notched-outline": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/base": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/floating-label": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "@material/shape": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
         "@material/ripple": {
           "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-14.0.0.tgz",
-          "integrity": "sha512-9XoGBFd5JhFgELgW7pqtiLy+CnCIcV2s9cQ2BWbOQeA8faX9UZIDUx/g76nHLZ7UzKFtsULJxZTwORmsEt2zvw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@material/animation": "^14.0.0",
@@ -15307,18 +16892,42 @@
         },
         "@material/rtl": {
           "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-14.0.0.tgz",
-          "integrity": "sha512-xl6OZYyRjuiW2hmbjV2omMV8sQtfmKAjeWnD1RMiAPLCTyOW9Lh/PYYnXjxUrNa0cRwIIbOn5J7OYXokja8puA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@material/theme": "^14.0.0",
             "tslib": "^2.1.0"
           }
         },
+        "@material/select": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/animation": "^14.0.0",
+            "@material/base": "^14.0.0",
+            "@material/density": "^14.0.0",
+            "@material/dom": "^14.0.0",
+            "@material/elevation": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/floating-label": "^14.0.0",
+            "@material/line-ripple": "^14.0.0",
+            "@material/list": "^14.0.0",
+            "@material/menu": "^14.0.0",
+            "@material/menu-surface": "^14.0.0",
+            "@material/notched-outline": "^14.0.0",
+            "@material/ripple": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "@material/shape": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "@material/tokens": "^14.0.0",
+            "@material/typography": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
         "@material/shape": {
           "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/shape/-/shape-14.0.0.tgz",
-          "integrity": "sha512-o0mJB0+feOv473KckI8gFnUo8IQAaEA6ynXzw3VIYFjPi48pJwrxa0mZcJP/OoTXrCbDzDeFJfDPXEmRioBb9A==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@material/feature-targeting": "^14.0.0",
@@ -15329,8 +16938,7 @@
         },
         "@material/theme": {
           "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0.tgz",
-          "integrity": "sha512-6/SENWNIFuXzeHMPHrYwbsXKgkvCtWuzzQ3cUu4UEt3KcQ5YpViazIM6h8ByYKZP8A9d8QpkJ0WGX5btGDcVoA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@material/feature-targeting": "^14.0.0",
@@ -15339,8 +16947,7 @@
         },
         "@material/tokens": {
           "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-14.0.0.tgz",
-          "integrity": "sha512-SXgB9VwsKW4DFkHmJfDIS0x0cGdMWC1D06m6z/WQQ5P5j6/m0pKrbHVlrLzXcRjau+mFhXGvj/KyPo9Pp/Rc8Q==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@material/elevation": "^14.0.0"
@@ -15360,8 +16967,7 @@
         },
         "@material/typography": {
           "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@material/typography/-/typography-14.0.0.tgz",
-          "integrity": "sha512-/QtHBYiTR+TPMryM/CT386B2WlAQf/Ae32V324Z7P40gHLKY/YBXx7FDutAWZFeOerq/two4Nd2aAHBcMM2wMw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@material/feature-targeting": "^14.0.0",
@@ -15388,13 +16994,12 @@
           }
         },
         "@smui/common": {
-          "version": "7.0.0-beta.15",
-          "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
-          "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
+          "version": "7.0.0-beta.14",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@material/dom": "^14.0.0",
-            "svelte2tsx": "^0.6.21"
+            "svelte2tsx": "^0.6.15"
           }
         },
         "@smui/fab": {
@@ -15408,6 +17013,74 @@
             "@smui/common": "^7.0.0-beta.15",
             "@smui/ripple": "^7.0.0-beta.15",
             "svelte2tsx": "^0.6.21"
+          }
+        },
+        "@smui/floating-label": {
+          "version": "7.0.0-beta.14",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/floating-label": "^14.0.0",
+            "@smui/common": "^7.0.0-beta.14",
+            "svelte2tsx": "^0.6.15"
+          }
+        },
+        "@smui/line-ripple": {
+          "version": "7.0.0-beta.14",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/line-ripple": "^14.0.0",
+            "@smui/common": "^7.0.0-beta.14",
+            "svelte2tsx": "^0.6.15"
+          }
+        },
+        "@smui/list": {
+          "version": "7.0.0-beta.14",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/dom": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/list": "^14.0.0",
+            "@smui/common": "^7.0.0-beta.14",
+            "@smui/ripple": "^7.0.0-beta.14",
+            "svelte2tsx": "^0.6.15"
+          }
+        },
+        "@smui/menu": {
+          "version": "7.0.0-beta.14",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/dom": "^14.0.0",
+            "@material/menu": "^14.0.0",
+            "@smui/common": "^7.0.0-beta.14",
+            "@smui/list": "^7.0.0-beta.14",
+            "@smui/menu-surface": "^7.0.0-beta.14",
+            "svelte2tsx": "^0.6.15"
+          }
+        },
+        "@smui/menu-surface": {
+          "version": "7.0.0-beta.14",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/animation": "^14.0.0",
+            "@material/menu-surface": "^14.0.0",
+            "@smui/common": "^7.0.0-beta.14",
+            "svelte2tsx": "^0.6.15"
+          }
+        },
+        "@smui/notched-outline": {
+          "version": "7.0.0-beta.14",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/notched-outline": "^14.0.0",
+            "@smui/common": "^7.0.0-beta.14",
+            "@smui/floating-label": "^7.0.0-beta.14",
+            "svelte2tsx": "^0.6.15"
           }
         },
         "@smui/paper": {
@@ -15426,15 +17099,35 @@
           }
         },
         "@smui/ripple": {
-          "version": "7.0.0-beta.15",
-          "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.15.tgz",
-          "integrity": "sha512-l0c94p60gxbsClH0KzA2meJ2IGHc7ZUMyWqODkLNz7ziUYxk3VZvWf/Y7Ca+64IJj0keCGPMpFauFaJO8h3Gtw==",
+          "version": "7.0.0-beta.14",
+          "bundled": true,
           "dev": true,
           "requires": {
             "@material/dom": "^14.0.0",
             "@material/ripple": "^14.0.0",
-            "@smui/common": "^7.0.0-beta.15",
-            "svelte2tsx": "^0.6.21"
+            "@smui/common": "^7.0.0-beta.14",
+            "svelte2tsx": "^0.6.15"
+          }
+        },
+        "@smui/select": {
+          "version": "7.0.0-beta.14",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/feature-targeting": "^14.0.0",
+            "@material/ripple": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "@material/select": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "@smui/common": "^7.0.0-beta.14",
+            "@smui/floating-label": "^7.0.0-beta.14",
+            "@smui/line-ripple": "^7.0.0-beta.14",
+            "@smui/list": "^7.0.0-beta.14",
+            "@smui/menu": "^7.0.0-beta.14",
+            "@smui/menu-surface": "^7.0.0-beta.14",
+            "@smui/notched-outline": "^7.0.0-beta.14",
+            "@smui/ripple": "^7.0.0-beta.14",
+            "svelte2tsx": "^0.6.15"
           }
         },
         "ansi-styles": {
@@ -15457,9 +17150,9 @@
           }
         },
         "ci-info": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
-          "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+          "version": "3.9.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+          "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
           "dev": true
         },
         "color-convert": {
@@ -15488,6 +17181,16 @@
             "which": "^2.0.1"
           }
         },
+        "dedent-js": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "fast-safe-stringify": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
         "fs-extra": {
           "version": "9.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -15506,6 +17209,15 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "isomorphic-fetch": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "node-fetch": "^2.6.1",
+            "whatwg-fetch": "^3.4.1"
+          }
+        },
         "jsonfile": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -15514,6 +17226,40 @@
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
+          }
+        },
+        "lower-case": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "tslib": "^2.0.3"
+          }
+        },
+        "no-case": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lower-case": "^2.0.2",
+            "tslib": "^2.0.3"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "pascal-case": {
+          "version": "3.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "no-case": "^3.0.4",
+            "tslib": "^2.0.3"
           }
         },
         "patch-package": {
@@ -15577,21 +17323,62 @@
             "has-flag": "^4.0.0"
           }
         },
+        "svelte-portal": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true
+        },
         "svelte2tsx": {
-          "version": "0.6.22",
-          "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.22.tgz",
-          "integrity": "sha512-eFCfz0juaWeanbwGeQV21kPMwH3LKhfrUYRy1PqRmlieuHvJs8VeK7CaoHJdpBZWCXba2cltHVdywJmwOGhbww==",
+          "version": "0.6.19",
+          "bundled": true,
           "dev": true,
           "requires": {
             "dedent-js": "^1.0.1",
             "pascal-case": "^3.1.1"
           }
         },
+        "tr46": {
+          "version": "0.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "tslib": {
+          "version": "2.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "typescript": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+          "bundled": true,
+          "dev": true,
+          "peer": true
+        },
         "universalify": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
           "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
           "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "whatwg-fetch": {
+          "version": "3.6.2",
+          "bundled": true,
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
         },
         "which": {
           "version": "2.0.2",
@@ -16005,12 +17792,6 @@
         }
       }
     },
-    "svelte-portal": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/svelte-portal/-/svelte-portal-2.2.0.tgz",
-      "integrity": "sha512-jhtZWtD6cUE2nMw46dJ5VXWYiqnER+JH+V/BmNBQ5fNP/YdsJCpJi+DemUy9msklqGb0f+wLhJPBtKHLWQvzjg==",
-      "dev": true
-    },
     "svelte-preprocess": {
       "version": "4.10.7",
       "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz",
@@ -16135,8 +17916,7 @@
     "typescript": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
     },
     "universalify": {
       "version": "0.1.2",
@@ -16196,12 +17976,6 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true
     },
-    "whatwg-fetch": {
-      "version": "3.6.17",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.17.tgz",
-      "integrity": "sha512-c4ghIvG6th0eudYwKZY5keb81wtFz9/WeAHAoy8+r18kcWlitUIrmGFQ2rWEl4UCKUilD3zCLHOIPheHx5ypRQ==",
-      "dev": true
-    },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -16220,6 +17994,13 @@
       "requires": {
         "isexe": "^2.0.0"
       }
+    },
+    "workerpool": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+      "dev": true,
+      "peer": true
     },
     "wrap-ansi": {
       "version": "7.0.0",
@@ -16268,7 +18049,8 @@
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "y18n": {
       "version": "5.0.8",
@@ -16283,9 +18065,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.3.tgz",
+      "integrity": "sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==",
       "dev": true
     },
     "yargs": {
@@ -16322,11 +18104,31 @@
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true
     },
+    "yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      }
+    },
     "yn": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
       "integrity": "sha512-uTv8J/wiWTgUTg+9vLTi//leUl5vDQS6uii/emeTb2ssY7vl6QWf2fFbIIGjnhjvbdKlU0ed7QPgY1htTC86jQ==",
       "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "peer": true
     }
   }
 }

--- a/src/routers/Search/dashboard/package.json
+++ b/src/routers/Search/dashboard/package.json
@@ -44,7 +44,7 @@
     "svelte": "^3.0.0",
     "svelte-check": "^2.0.0",
     "svelte-file-dropzone": "^1.0.0",
-    "svelte-jsonschema-form": "github:webgme/svelte-jsonschema-form#v0.6.0",
+    "svelte-jsonschema-form": "github:webgme/svelte-jsonschema-form#v0.6.4",
     "svelte-preprocess": "^4.0.0",
     "ts-mocha": "^10.0.0",
     "tslib": "^2.0.0",

--- a/src/routers/TagCreator/form/package-lock.json
+++ b/src/routers/TagCreator/form/package-lock.json
@@ -19,7 +19,7 @@
         "smui-theme": "^7.0.0-beta.14",
         "svelte": "^4.1.2",
         "svelte-check": "^3.4.6",
-        "svelte-jsonschema-form": "github:webgme/svelte-jsonschema-form#v0.6.0",
+        "svelte-jsonschema-form": "github:webgme/svelte-jsonschema-form#v0.6.4",
         "svelte-preprocess": "^5.0.4",
         "tslib": "^2.6.1",
         "typescript": "^5.1.6",
@@ -439,39 +439,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@json-schema-spec/json-pointer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@json-schema-spec/json-pointer/-/json-pointer-0.1.2.tgz",
-      "integrity": "sha512-BYY7IavBjwsWWSmVcMz2A9mKiDD9RvacnsItgmy1xV8cmgbtxFfKmKMtkVpD7pYtkx4mIW4800yZBXueVFIWPw==",
-      "dev": true
-    },
-    "node_modules/@json-schema-tools/dereferencer": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/dereferencer/-/dereferencer-1.6.1.tgz",
-      "integrity": "sha512-+h+K/H3pWoJVztTuz1ycTUc0ai/xH5eLZLurE4jQpqYwPcPvsXtFfbRxDhvxrrpjjg4PV3HmEjjORIEQPO4Dmw==",
-      "dev": true,
-      "dependencies": {
-        "@json-schema-tools/reference-resolver": "^1.2.5",
-        "@json-schema-tools/traverse": "^1.10.0",
-        "fast-safe-stringify": "^2.1.1"
-      }
-    },
-    "node_modules/@json-schema-tools/reference-resolver": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/reference-resolver/-/reference-resolver-1.2.5.tgz",
-      "integrity": "sha512-xNQgX/ABnwvbIeexL5Czv08lXjHAL80HEUogza7E19eIL/EXD8HM4FvxG1JuTGyi5fA+sSP64C9pabELizcBBw==",
-      "dev": true,
-      "dependencies": {
-        "@json-schema-spec/json-pointer": "^0.1.2",
-        "isomorphic-fetch": "^3.0.0"
-      }
-    },
-    "node_modules/@json-schema-tools/traverse": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/traverse/-/traverse-1.10.1.tgz",
-      "integrity": "sha512-vYY5EIxCPzEXEWL/vTjdHy4g92tv1ApUQCjPJsj9gEoXLNNVwJlwwgRZisuvgFBZ3zeLzQygrbehERSpYdmFZA==",
-      "dev": true
-    },
     "node_modules/@material/animation": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/@material/animation/-/animation-14.0.0.tgz",
@@ -681,58 +648,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/@material/list": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/list/-/list-14.0.0.tgz",
-      "integrity": "sha512-AFaBGV9vQyfnG8BT2R3UGVdF5w2SigQqBH+qbOSxQhk4BgVvhDfJUIKT415poLNMdnaDtcuYz+ZWvVNoRDaL7w==",
-      "dev": true,
-      "dependencies": {
-        "@material/base": "^14.0.0",
-        "@material/density": "^14.0.0",
-        "@material/dom": "^14.0.0",
-        "@material/feature-targeting": "^14.0.0",
-        "@material/ripple": "^14.0.0",
-        "@material/rtl": "^14.0.0",
-        "@material/shape": "^14.0.0",
-        "@material/theme": "^14.0.0",
-        "@material/typography": "^14.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@material/menu": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/menu/-/menu-14.0.0.tgz",
-      "integrity": "sha512-oU6GjbYnkG6a5nX9HUSege5OQByf6yUteEij8fpf0ci3f5BWf/gr39dnQ+rfl+q119cW0WIEmVK2YJ/BFxMzEQ==",
-      "dev": true,
-      "dependencies": {
-        "@material/base": "^14.0.0",
-        "@material/dom": "^14.0.0",
-        "@material/elevation": "^14.0.0",
-        "@material/feature-targeting": "^14.0.0",
-        "@material/list": "^14.0.0",
-        "@material/menu-surface": "^14.0.0",
-        "@material/ripple": "^14.0.0",
-        "@material/rtl": "^14.0.0",
-        "@material/theme": "^14.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@material/menu-surface": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/menu-surface/-/menu-surface-14.0.0.tgz",
-      "integrity": "sha512-wRz3UCrhJ4kRrijJEbvIPRa0mqA5qkQmKXjBH4Xu1ApedZruP+OM3Qb2Bj4XugCA3eCXpiohg+gdyTAX3dVQyw==",
-      "dev": true,
-      "dependencies": {
-        "@material/animation": "^14.0.0",
-        "@material/base": "^14.0.0",
-        "@material/elevation": "^14.0.0",
-        "@material/feature-targeting": "^14.0.0",
-        "@material/rtl": "^14.0.0",
-        "@material/shape": "^14.0.0",
-        "@material/theme": "^14.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/@material/notched-outline": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/@material/notched-outline/-/notched-outline-14.0.0.tgz",
@@ -779,33 +694,6 @@
       "dev": true,
       "dependencies": {
         "@material/theme": "^14.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@material/select": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/select/-/select-14.0.0.tgz",
-      "integrity": "sha512-4aY1kUHEnbOCRG3Tkuuk8yFfyNYSvOstBbjiYE/Z1ZGF3P1z+ON35iLatP84LvNteX4F1EMO2QAta2QbLRMAkw==",
-      "dev": true,
-      "dependencies": {
-        "@material/animation": "^14.0.0",
-        "@material/base": "^14.0.0",
-        "@material/density": "^14.0.0",
-        "@material/dom": "^14.0.0",
-        "@material/elevation": "^14.0.0",
-        "@material/feature-targeting": "^14.0.0",
-        "@material/floating-label": "^14.0.0",
-        "@material/line-ripple": "^14.0.0",
-        "@material/list": "^14.0.0",
-        "@material/menu": "^14.0.0",
-        "@material/menu-surface": "^14.0.0",
-        "@material/notched-outline": "^14.0.0",
-        "@material/ripple": "^14.0.0",
-        "@material/rtl": "^14.0.0",
-        "@material/shape": "^14.0.0",
-        "@material/theme": "^14.0.0",
-        "@material/tokens": "^14.0.0",
-        "@material/typography": "^14.0.0",
         "tslib": "^2.1.0"
       }
     },
@@ -960,9 +848,9 @@
       }
     },
     "node_modules/@smui-extra/accordion": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui-extra/accordion/-/accordion-7.0.0-beta.14.tgz",
-      "integrity": "sha512-9AkMG3EOJngfKwhkufyUvo+VkS42dRRRbc09UpcW6r1lvbnmfinZfc8EYWQl5ijKCepwnRl1vUsnjH+V+XfByg==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui-extra/accordion/-/accordion-7.0.0-beta.15.tgz",
+      "integrity": "sha512-/T5RX6akQRCuo82YMLr3VbmVOdnzO+Vn0zy0PWIOB8YqiSf6ny5T4cY3lENwN9hrAeA5JuMQ8mQbyoa2KWMgbw==",
       "dev": true,
       "dependencies": {
         "@material/animation": "^14.0.0",
@@ -971,10 +859,10 @@
         "@material/ripple": "^14.0.0",
         "@material/theme": "^14.0.0",
         "@material/typography": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "@smui/paper": "^7.0.0-beta.14",
-        "@smui/ripple": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/paper": "^7.0.0-beta.15",
+        "@smui/ripple": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/button": {
@@ -995,15 +883,15 @@
       }
     },
     "node_modules/@smui/checkbox": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/checkbox/-/checkbox-7.0.0-beta.14.tgz",
-      "integrity": "sha512-tQV/9VJC7cxktR5/pXsK34+FPGmc0tWDHfEQBMK35Pbm1jdp99mbj/5ZaaM/43NYj94ynOo7imRmNkWyXSCJng==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/checkbox/-/checkbox-7.0.0-beta.15.tgz",
+      "integrity": "sha512-lDRHkec8qCNz8SAdV8G1XoFLdj340OVK0KoEszo/KTu+eIfIfkiIKrvZj5TEb8ohGV1j0QuaOivlhnP+CNDERA==",
       "dev": true,
       "dependencies": {
         "@material/checkbox": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "@smui/ripple": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/ripple": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/circular-progress": {
@@ -1018,50 +906,50 @@
       }
     },
     "node_modules/@smui/common": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.14.tgz",
-      "integrity": "sha512-Vw0fth7DiFKoVSJb5UMiXxACMyF65Wof/W23nEywx9rAh/v7kF7gi565d9BZp4sYvFj3hPy2M2Ev3p2tnxzLOw==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
+      "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
       "dev": true,
       "dependencies": {
         "@material/dom": "^14.0.0",
-        "svelte2tsx": "^0.6.15"
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/fab": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/fab/-/fab-7.0.0-beta.14.tgz",
-      "integrity": "sha512-ud+rkA1GyyV05idRI2BqQI2RIx0CgklQLfrunTmUB5HKg5PIkOWxOOBEUjNSOwKCBpJRkizM12xVz8XXoDJcJA==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/fab/-/fab-7.0.0-beta.15.tgz",
+      "integrity": "sha512-mO7hscDVA4YslTtB4dxWLNkxl1U/ZKSskglLNKrFWvjCd/MiOSVZSyMODkGnLaeQFMfgGus7moGqS+nY+hvvsQ==",
       "dev": true,
       "dependencies": {
         "@material/fab": "^14.0.0",
         "@material/feature-targeting": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "@smui/ripple": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/ripple": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/floating-label": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/floating-label/-/floating-label-7.0.0-beta.14.tgz",
-      "integrity": "sha512-VVXWJ15paZlqrnUl2FKsF81KSDjV/uWaTTRIT1kEW/McTce4xPpxk5P/pPF665yNbbBhnSRmnjSI+B63bhJpSg==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/floating-label/-/floating-label-7.0.0-beta.15.tgz",
+      "integrity": "sha512-KRjZjO8AGE5uKHewmn05vyAxIi6XOGo8a4jn8b0+dIJcYxaPpmtacH4PeQHw4vOR88cX/0DqqxSz6+Fkrt+SIA==",
       "dev": true,
       "dependencies": {
         "@material/floating-label": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/form-field": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/form-field/-/form-field-7.0.0-beta.14.tgz",
-      "integrity": "sha512-OpBOoDma9cDyks6LWNYa6sNmHeW9U+18XA/NlIDvZeP6/+YcmebAtr9cJ89mpiOSYxp/VfOzBExpaHqkyXtVlw==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/form-field/-/form-field-7.0.0-beta.15.tgz",
+      "integrity": "sha512-Ou2Og5pVkktrhPW0c+eA+A6O9WJrpqmOh+ZqekQfixiJRmP13645NRk3qbA0NUoIBb6m+9wJ2KbEoZ0yrHWnaw==",
       "dev": true,
       "dependencies": {
         "@material/feature-targeting": "^14.0.0",
         "@material/form-field": "^14.0.0",
         "@material/rtl": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/icon-button": {
@@ -1078,72 +966,32 @@
       }
     },
     "node_modules/@smui/line-ripple": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/line-ripple/-/line-ripple-7.0.0-beta.14.tgz",
-      "integrity": "sha512-9BsByyEizUPG7b4VRX3Wahmb300wlJSxgyY1EYVIna1mnKRXwvBp2TKjAnOZ8y8tKhOlfLJXFI8uVoEGnLK8BA==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/line-ripple/-/line-ripple-7.0.0-beta.15.tgz",
+      "integrity": "sha512-tfdEybgQlLiotELlWknLzb5l6pT47uGfMGYzLs5AVf74CU/zAhp8NiicHUUmI95qY5P2z2xHYYpdLTs1wZ5c9A==",
       "dev": true,
       "dependencies": {
         "@material/line-ripple": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
-      }
-    },
-    "node_modules/@smui/list": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/list/-/list-7.0.0-beta.14.tgz",
-      "integrity": "sha512-HzHxe360OcnNpbdp6mmcAk98kTks/R4FjlV6mb54HRVfYjMB3ZvzUzKE/kz0BRzkRXFVXQN9llEL+eDASOTA4A==",
-      "dev": true,
-      "dependencies": {
-        "@material/dom": "^14.0.0",
-        "@material/feature-targeting": "^14.0.0",
-        "@material/list": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "@smui/ripple": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
-      }
-    },
-    "node_modules/@smui/menu": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/menu/-/menu-7.0.0-beta.14.tgz",
-      "integrity": "sha512-CdHdvy9X+qYTzARD+k3op/j90fSQCKkDINog8Y7O1WNxU6sFIhVTVlQWPq6y94VoOIBENJIsukjpGUuEmjZQZw==",
-      "dev": true,
-      "dependencies": {
-        "@material/dom": "^14.0.0",
-        "@material/menu": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "@smui/list": "^7.0.0-beta.14",
-        "@smui/menu-surface": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
-      }
-    },
-    "node_modules/@smui/menu-surface": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/menu-surface/-/menu-surface-7.0.0-beta.14.tgz",
-      "integrity": "sha512-2wo7GXNt6+JRiWjy+ocwnkLaFwRMQ0glJusZl/azPO9qCNyjMCisL2iU9wSGExCkjUnCGutCre0Zb63BwRhiQw==",
-      "dev": true,
-      "dependencies": {
-        "@material/animation": "^14.0.0",
-        "@material/menu-surface": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/notched-outline": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/notched-outline/-/notched-outline-7.0.0-beta.14.tgz",
-      "integrity": "sha512-gblu47Jrn6ifEm86FGfkwaR2uG7yyiZgvZb2oxrv/fULFHIVZ5b9hHbHuv3PlDmxT79J+Z2OIxb55dOKxGQ8Ng==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/notched-outline/-/notched-outline-7.0.0-beta.15.tgz",
+      "integrity": "sha512-9oVSIYmb1/GcCFYm1M0xVy4J5/A2Ysa4H6gm3RIL9/ke3F9EmmALmCs1lmtGu4Vwyo0ES5KroW2Tly2SzMfB2g==",
       "dev": true,
       "dependencies": {
         "@material/notched-outline": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "@smui/floating-label": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/floating-label": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/paper": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/paper/-/paper-7.0.0-beta.14.tgz",
-      "integrity": "sha512-qz8lge3p0oJIIazTCMOfjdmEeilO5vMlU2bAmsQtbPqqP6v+wV5K+f/zXnSHtziIYd4fjlTW9bgxmkmf7r4uEA==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/paper/-/paper-7.0.0-beta.15.tgz",
+      "integrity": "sha512-qJgu41Gn/5fjhzo9rEhVnYm3U2SL9ECCD1nfmqbRMUzVlaeWrlSwWqJcJSAR6Og2ya8BYBoJetbxUdlLU8X9GA==",
       "dev": true,
       "dependencies": {
         "@material/elevation": "^14.0.0",
@@ -1151,42 +999,20 @@
         "@material/shape": "^14.0.0",
         "@material/theme": "^14.0.0",
         "@material/typography": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/ripple": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.14.tgz",
-      "integrity": "sha512-EQyZIicnJj3mNCXK1PuGQ4zZOdXrhRtcHGJCrTUNjQzltIQai446Y9aRk5PhY3EIWfTYZuWnqaprC6R00EJOKA==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.15.tgz",
+      "integrity": "sha512-l0c94p60gxbsClH0KzA2meJ2IGHc7ZUMyWqODkLNz7ziUYxk3VZvWf/Y7Ca+64IJj0keCGPMpFauFaJO8h3Gtw==",
       "dev": true,
       "dependencies": {
         "@material/dom": "^14.0.0",
         "@material/ripple": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
-      }
-    },
-    "node_modules/@smui/select": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/select/-/select-7.0.0-beta.14.tgz",
-      "integrity": "sha512-pv3xdnbHLYE72qFfTy3Kx/sTsezyHheEdcXNeQ6DKZ9v/2RcJzlQSA/Q/Qj559ZWH1m6XOK9kXk1HjtsaQk6bg==",
-      "dev": true,
-      "dependencies": {
-        "@material/feature-targeting": "^14.0.0",
-        "@material/ripple": "^14.0.0",
-        "@material/rtl": "^14.0.0",
-        "@material/select": "^14.0.0",
-        "@material/theme": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "@smui/floating-label": "^7.0.0-beta.14",
-        "@smui/line-ripple": "^7.0.0-beta.14",
-        "@smui/list": "^7.0.0-beta.14",
-        "@smui/menu": "^7.0.0-beta.14",
-        "@smui/menu-surface": "^7.0.0-beta.14",
-        "@smui/notched-outline": "^7.0.0-beta.14",
-        "@smui/ripple": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/snackbar": {
@@ -1206,9 +1032,9 @@
       }
     },
     "node_modules/@smui/textfield": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/textfield/-/textfield-7.0.0-beta.14.tgz",
-      "integrity": "sha512-bFAHuECVrNxeHdLgirkhtzbytZ8WqyV4aOv4pmTm6SB/K8YgdnzKT8DLWzvx3Ma+OkV1E//u2DpvcvnpB+VN4g==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/textfield/-/textfield-7.0.0-beta.15.tgz",
+      "integrity": "sha512-98lGaVJRH3K5aXVUAa8o/8rHRQ/Vwu9q6phupSrPW4BEmEEEezb/fzKExTOgm0c241dy4nDRLkdH9IdtObTA8w==",
       "dev": true,
       "dependencies": {
         "@material/dom": "^14.0.0",
@@ -1216,12 +1042,12 @@
         "@material/ripple": "^14.0.0",
         "@material/rtl": "^14.0.0",
         "@material/textfield": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "@smui/floating-label": "^7.0.0-beta.14",
-        "@smui/line-ripple": "^7.0.0-beta.14",
-        "@smui/notched-outline": "^7.0.0-beta.14",
-        "@smui/ripple": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/floating-label": "^7.0.0-beta.15",
+        "@smui/line-ripple": "^7.0.0-beta.15",
+        "@smui/notched-outline": "^7.0.0-beta.15",
+        "@smui/ripple": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "node_modules/@smui/top-app-bar": {
@@ -1519,9 +1345,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
-      "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
       "dev": true,
       "funding": [
         {
@@ -1608,9 +1434,9 @@
       "dev": true
     },
     "node_modules/core-js": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.0.tgz",
-      "integrity": "sha512-rd4rYZNlF3WuoYuRIDEmbR/ga9CeuWX9U05umAvgrrZoHY4Z++cp/xwPQMvUpBB4Ag6J8KfD80G0zwCyaSxDww==",
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.1.tgz",
+      "integrity": "sha512-qVSq3s+d4+GsqN0teRCJtM6tdEEXyWxjzbhVrCHmBS5ZTM0FS2MOS0D13dUXAWDUN6a+lHI/N1hF9Ytz6iLl9Q==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -1783,12 +1609,6 @@
       "engines": {
         "node": ">=8.6.0"
       }
-    },
-    "node_modules/fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -2054,16 +1874,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
-    },
-    "node_modules/isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
     },
     "node_modules/json-schema-compare": {
       "version": "0.2.2",
@@ -2835,8 +2645,13 @@
       }
     },
     "node_modules/svelte-jsonschema-form": {
-      "version": "0.6.0",
-      "resolved": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#d3247a9066399acc032c625a2af4cb99682745fa",
+      "version": "0.6.4",
+      "resolved": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#0999ae10bd9907e6867acaf38cfb76011ee9be2e",
+      "bundleDependencies": [
+        "@json-schema-tools/dereferencer",
+        "@smui/select",
+        "svelte-portal"
+      ],
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2863,11 +2678,531 @@
         "svelte": "^3.50 || ^4"
       }
     },
-    "node_modules/svelte-portal": {
+    "node_modules/svelte-jsonschema-form/node_modules/@json-schema-spec/json-pointer": {
+      "version": "0.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@json-schema-tools/dereferencer": {
+      "version": "1.6.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@json-schema-tools/reference-resolver": "^1.2.5",
+        "@json-schema-tools/traverse": "^1.10.0",
+        "fast-safe-stringify": "^2.1.1"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@json-schema-tools/reference-resolver": {
+      "version": "1.2.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@json-schema-spec/json-pointer": "^0.1.2",
+        "isomorphic-fetch": "^3.0.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@json-schema-tools/traverse": {
+      "version": "1.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/animation": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/base": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/density": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/dom": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/elevation": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "^14.0.0",
+        "@material/base": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/feature-targeting": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/floating-label": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "^14.0.0",
+        "@material/base": "^14.0.0",
+        "@material/dom": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "@material/typography": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/line-ripple": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "^14.0.0",
+        "@material/base": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/list": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "^14.0.0",
+        "@material/density": "^14.0.0",
+        "@material/dom": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/ripple": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/shape": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "@material/typography": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/menu": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "^14.0.0",
+        "@material/dom": "^14.0.0",
+        "@material/elevation": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/list": "^14.0.0",
+        "@material/menu-surface": "^14.0.0",
+        "@material/ripple": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/menu-surface": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "^14.0.0",
+        "@material/base": "^14.0.0",
+        "@material/elevation": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/shape": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/notched-outline": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/base": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/floating-label": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/shape": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/ripple": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "^14.0.0",
+        "@material/base": "^14.0.0",
+        "@material/dom": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/rtl": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/theme": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/select": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/animation": "^14.0.0",
+        "@material/base": "^14.0.0",
+        "@material/density": "^14.0.0",
+        "@material/dom": "^14.0.0",
+        "@material/elevation": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/floating-label": "^14.0.0",
+        "@material/line-ripple": "^14.0.0",
+        "@material/list": "^14.0.0",
+        "@material/menu": "^14.0.0",
+        "@material/menu-surface": "^14.0.0",
+        "@material/notched-outline": "^14.0.0",
+        "@material/ripple": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/shape": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "@material/tokens": "^14.0.0",
+        "@material/typography": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/shape": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/theme": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/tokens": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/elevation": "^14.0.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@material/typography": {
+      "version": "14.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@material/feature-targeting": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@smui/common": {
+      "version": "7.0.0-beta.14",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/dom": "^14.0.0",
+        "svelte2tsx": "^0.6.15"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@smui/floating-label": {
+      "version": "7.0.0-beta.14",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/floating-label": "^14.0.0",
+        "@smui/common": "^7.0.0-beta.14",
+        "svelte2tsx": "^0.6.15"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@smui/line-ripple": {
+      "version": "7.0.0-beta.14",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/line-ripple": "^14.0.0",
+        "@smui/common": "^7.0.0-beta.14",
+        "svelte2tsx": "^0.6.15"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@smui/list": {
+      "version": "7.0.0-beta.14",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/dom": "^14.0.0",
+        "@material/feature-targeting": "^14.0.0",
+        "@material/list": "^14.0.0",
+        "@smui/common": "^7.0.0-beta.14",
+        "@smui/ripple": "^7.0.0-beta.14",
+        "svelte2tsx": "^0.6.15"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@smui/menu": {
+      "version": "7.0.0-beta.14",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/dom": "^14.0.0",
+        "@material/menu": "^14.0.0",
+        "@smui/common": "^7.0.0-beta.14",
+        "@smui/list": "^7.0.0-beta.14",
+        "@smui/menu-surface": "^7.0.0-beta.14",
+        "svelte2tsx": "^0.6.15"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@smui/menu-surface": {
+      "version": "7.0.0-beta.14",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/animation": "^14.0.0",
+        "@material/menu-surface": "^14.0.0",
+        "@smui/common": "^7.0.0-beta.14",
+        "svelte2tsx": "^0.6.15"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@smui/notched-outline": {
+      "version": "7.0.0-beta.14",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/notched-outline": "^14.0.0",
+        "@smui/common": "^7.0.0-beta.14",
+        "@smui/floating-label": "^7.0.0-beta.14",
+        "svelte2tsx": "^0.6.15"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@smui/ripple": {
+      "version": "7.0.0-beta.14",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/dom": "^14.0.0",
+        "@material/ripple": "^14.0.0",
+        "@smui/common": "^7.0.0-beta.14",
+        "svelte2tsx": "^0.6.15"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/@smui/select": {
+      "version": "7.0.0-beta.14",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@material/feature-targeting": "^14.0.0",
+        "@material/ripple": "^14.0.0",
+        "@material/rtl": "^14.0.0",
+        "@material/select": "^14.0.0",
+        "@material/theme": "^14.0.0",
+        "@smui/common": "^7.0.0-beta.14",
+        "@smui/floating-label": "^7.0.0-beta.14",
+        "@smui/line-ripple": "^7.0.0-beta.14",
+        "@smui/list": "^7.0.0-beta.14",
+        "@smui/menu": "^7.0.0-beta.14",
+        "@smui/menu-surface": "^7.0.0-beta.14",
+        "@smui/notched-outline": "^7.0.0-beta.14",
+        "@smui/ripple": "^7.0.0-beta.14",
+        "svelte2tsx": "^0.6.15"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/dedent-js": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/lower-case": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/no-case": {
+      "version": "3.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/node-fetch": {
+      "version": "2.6.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/pascal-case": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/svelte-portal": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/svelte-portal/-/svelte-portal-2.2.0.tgz",
-      "integrity": "sha512-jhtZWtD6cUE2nMw46dJ5VXWYiqnER+JH+V/BmNBQ5fNP/YdsJCpJi+DemUy9msklqGb0f+wLhJPBtKHLWQvzjg==",
-      "dev": true
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/svelte2tsx": {
+      "version": "0.6.19",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "dedent-js": "^1.0.1",
+        "pascal-case": "^3.1.1"
+      },
+      "peerDependencies": {
+        "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0",
+        "typescript": "^4.9.4 || ^5.0.0"
+      }
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/tr46": {
+      "version": "0.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/tslib": {
+      "version": "2.5.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD"
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/whatwg-fetch": {
+      "version": "3.6.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/svelte-jsonschema-form/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/svelte-preprocess": {
       "version": "5.0.4",
@@ -2944,9 +3279,9 @@
       }
     },
     "node_modules/svelte2tsx": {
-      "version": "0.6.19",
-      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.19.tgz",
-      "integrity": "sha512-h3b5OtcO8zyVL/RiB2zsDwCopeo/UH+887uyhgb2mjnewOFwiTxu+4IGuVwrrlyuh2onM2ktfUemNrNmQwXONQ==",
+      "version": "0.6.23",
+      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.23.tgz",
+      "integrity": "sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==",
       "dev": true,
       "dependencies": {
         "dedent-js": "^1.0.1",
@@ -3136,12 +3471,6 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true
     },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.17",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.17.tgz",
-      "integrity": "sha512-c4ghIvG6th0eudYwKZY5keb81wtFz9/WeAHAoy8+r18kcWlitUIrmGFQ2rWEl4UCKUilD3zCLHOIPheHx5ypRQ==",
-      "dev": true
-    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -3206,9 +3535,9 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.3.tgz",
+      "integrity": "sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==",
       "dev": true,
       "engines": {
         "node": ">= 14"
@@ -3446,39 +3775,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "@json-schema-spec/json-pointer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@json-schema-spec/json-pointer/-/json-pointer-0.1.2.tgz",
-      "integrity": "sha512-BYY7IavBjwsWWSmVcMz2A9mKiDD9RvacnsItgmy1xV8cmgbtxFfKmKMtkVpD7pYtkx4mIW4800yZBXueVFIWPw==",
-      "dev": true
-    },
-    "@json-schema-tools/dereferencer": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/dereferencer/-/dereferencer-1.6.1.tgz",
-      "integrity": "sha512-+h+K/H3pWoJVztTuz1ycTUc0ai/xH5eLZLurE4jQpqYwPcPvsXtFfbRxDhvxrrpjjg4PV3HmEjjORIEQPO4Dmw==",
-      "dev": true,
-      "requires": {
-        "@json-schema-tools/reference-resolver": "^1.2.5",
-        "@json-schema-tools/traverse": "^1.10.0",
-        "fast-safe-stringify": "^2.1.1"
-      }
-    },
-    "@json-schema-tools/reference-resolver": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/reference-resolver/-/reference-resolver-1.2.5.tgz",
-      "integrity": "sha512-xNQgX/ABnwvbIeexL5Czv08lXjHAL80HEUogza7E19eIL/EXD8HM4FvxG1JuTGyi5fA+sSP64C9pabELizcBBw==",
-      "dev": true,
-      "requires": {
-        "@json-schema-spec/json-pointer": "^0.1.2",
-        "isomorphic-fetch": "^3.0.0"
-      }
-    },
-    "@json-schema-tools/traverse": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@json-schema-tools/traverse/-/traverse-1.10.1.tgz",
-      "integrity": "sha512-vYY5EIxCPzEXEWL/vTjdHy4g92tv1ApUQCjPJsj9gEoXLNNVwJlwwgRZisuvgFBZ3zeLzQygrbehERSpYdmFZA==",
-      "dev": true
-    },
     "@material/animation": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/@material/animation/-/animation-14.0.0.tgz",
@@ -3688,58 +3984,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "@material/list": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/list/-/list-14.0.0.tgz",
-      "integrity": "sha512-AFaBGV9vQyfnG8BT2R3UGVdF5w2SigQqBH+qbOSxQhk4BgVvhDfJUIKT415poLNMdnaDtcuYz+ZWvVNoRDaL7w==",
-      "dev": true,
-      "requires": {
-        "@material/base": "^14.0.0",
-        "@material/density": "^14.0.0",
-        "@material/dom": "^14.0.0",
-        "@material/feature-targeting": "^14.0.0",
-        "@material/ripple": "^14.0.0",
-        "@material/rtl": "^14.0.0",
-        "@material/shape": "^14.0.0",
-        "@material/theme": "^14.0.0",
-        "@material/typography": "^14.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@material/menu": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/menu/-/menu-14.0.0.tgz",
-      "integrity": "sha512-oU6GjbYnkG6a5nX9HUSege5OQByf6yUteEij8fpf0ci3f5BWf/gr39dnQ+rfl+q119cW0WIEmVK2YJ/BFxMzEQ==",
-      "dev": true,
-      "requires": {
-        "@material/base": "^14.0.0",
-        "@material/dom": "^14.0.0",
-        "@material/elevation": "^14.0.0",
-        "@material/feature-targeting": "^14.0.0",
-        "@material/list": "^14.0.0",
-        "@material/menu-surface": "^14.0.0",
-        "@material/ripple": "^14.0.0",
-        "@material/rtl": "^14.0.0",
-        "@material/theme": "^14.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@material/menu-surface": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/menu-surface/-/menu-surface-14.0.0.tgz",
-      "integrity": "sha512-wRz3UCrhJ4kRrijJEbvIPRa0mqA5qkQmKXjBH4Xu1ApedZruP+OM3Qb2Bj4XugCA3eCXpiohg+gdyTAX3dVQyw==",
-      "dev": true,
-      "requires": {
-        "@material/animation": "^14.0.0",
-        "@material/base": "^14.0.0",
-        "@material/elevation": "^14.0.0",
-        "@material/feature-targeting": "^14.0.0",
-        "@material/rtl": "^14.0.0",
-        "@material/shape": "^14.0.0",
-        "@material/theme": "^14.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
     "@material/notched-outline": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/@material/notched-outline/-/notched-outline-14.0.0.tgz",
@@ -3786,33 +4030,6 @@
       "dev": true,
       "requires": {
         "@material/theme": "^14.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "@material/select": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@material/select/-/select-14.0.0.tgz",
-      "integrity": "sha512-4aY1kUHEnbOCRG3Tkuuk8yFfyNYSvOstBbjiYE/Z1ZGF3P1z+ON35iLatP84LvNteX4F1EMO2QAta2QbLRMAkw==",
-      "dev": true,
-      "requires": {
-        "@material/animation": "^14.0.0",
-        "@material/base": "^14.0.0",
-        "@material/density": "^14.0.0",
-        "@material/dom": "^14.0.0",
-        "@material/elevation": "^14.0.0",
-        "@material/feature-targeting": "^14.0.0",
-        "@material/floating-label": "^14.0.0",
-        "@material/line-ripple": "^14.0.0",
-        "@material/list": "^14.0.0",
-        "@material/menu": "^14.0.0",
-        "@material/menu-surface": "^14.0.0",
-        "@material/notched-outline": "^14.0.0",
-        "@material/ripple": "^14.0.0",
-        "@material/rtl": "^14.0.0",
-        "@material/shape": "^14.0.0",
-        "@material/theme": "^14.0.0",
-        "@material/tokens": "^14.0.0",
-        "@material/typography": "^14.0.0",
         "tslib": "^2.1.0"
       }
     },
@@ -3958,9 +4175,9 @@
       }
     },
     "@smui-extra/accordion": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui-extra/accordion/-/accordion-7.0.0-beta.14.tgz",
-      "integrity": "sha512-9AkMG3EOJngfKwhkufyUvo+VkS42dRRRbc09UpcW6r1lvbnmfinZfc8EYWQl5ijKCepwnRl1vUsnjH+V+XfByg==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui-extra/accordion/-/accordion-7.0.0-beta.15.tgz",
+      "integrity": "sha512-/T5RX6akQRCuo82YMLr3VbmVOdnzO+Vn0zy0PWIOB8YqiSf6ny5T4cY3lENwN9hrAeA5JuMQ8mQbyoa2KWMgbw==",
       "dev": true,
       "requires": {
         "@material/animation": "^14.0.0",
@@ -3969,10 +4186,10 @@
         "@material/ripple": "^14.0.0",
         "@material/theme": "^14.0.0",
         "@material/typography": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "@smui/paper": "^7.0.0-beta.14",
-        "@smui/ripple": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/paper": "^7.0.0-beta.15",
+        "@smui/ripple": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "@smui/button": {
@@ -3993,15 +4210,15 @@
       }
     },
     "@smui/checkbox": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/checkbox/-/checkbox-7.0.0-beta.14.tgz",
-      "integrity": "sha512-tQV/9VJC7cxktR5/pXsK34+FPGmc0tWDHfEQBMK35Pbm1jdp99mbj/5ZaaM/43NYj94ynOo7imRmNkWyXSCJng==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/checkbox/-/checkbox-7.0.0-beta.15.tgz",
+      "integrity": "sha512-lDRHkec8qCNz8SAdV8G1XoFLdj340OVK0KoEszo/KTu+eIfIfkiIKrvZj5TEb8ohGV1j0QuaOivlhnP+CNDERA==",
       "dev": true,
       "requires": {
         "@material/checkbox": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "@smui/ripple": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/ripple": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "@smui/circular-progress": {
@@ -4016,50 +4233,50 @@
       }
     },
     "@smui/common": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.14.tgz",
-      "integrity": "sha512-Vw0fth7DiFKoVSJb5UMiXxACMyF65Wof/W23nEywx9rAh/v7kF7gi565d9BZp4sYvFj3hPy2M2Ev3p2tnxzLOw==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/common/-/common-7.0.0-beta.15.tgz",
+      "integrity": "sha512-mrK7B75L9so6EtzRolkAZkatC1sKHAP+gvIjU+JSfmSJnaRuglTS5ZTcosEmP759GA7E4scAQtOY1Qw7BgVO/g==",
       "dev": true,
       "requires": {
         "@material/dom": "^14.0.0",
-        "svelte2tsx": "^0.6.15"
+        "svelte2tsx": "^0.6.21"
       }
     },
     "@smui/fab": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/fab/-/fab-7.0.0-beta.14.tgz",
-      "integrity": "sha512-ud+rkA1GyyV05idRI2BqQI2RIx0CgklQLfrunTmUB5HKg5PIkOWxOOBEUjNSOwKCBpJRkizM12xVz8XXoDJcJA==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/fab/-/fab-7.0.0-beta.15.tgz",
+      "integrity": "sha512-mO7hscDVA4YslTtB4dxWLNkxl1U/ZKSskglLNKrFWvjCd/MiOSVZSyMODkGnLaeQFMfgGus7moGqS+nY+hvvsQ==",
       "dev": true,
       "requires": {
         "@material/fab": "^14.0.0",
         "@material/feature-targeting": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "@smui/ripple": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/ripple": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "@smui/floating-label": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/floating-label/-/floating-label-7.0.0-beta.14.tgz",
-      "integrity": "sha512-VVXWJ15paZlqrnUl2FKsF81KSDjV/uWaTTRIT1kEW/McTce4xPpxk5P/pPF665yNbbBhnSRmnjSI+B63bhJpSg==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/floating-label/-/floating-label-7.0.0-beta.15.tgz",
+      "integrity": "sha512-KRjZjO8AGE5uKHewmn05vyAxIi6XOGo8a4jn8b0+dIJcYxaPpmtacH4PeQHw4vOR88cX/0DqqxSz6+Fkrt+SIA==",
       "dev": true,
       "requires": {
         "@material/floating-label": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "@smui/form-field": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/form-field/-/form-field-7.0.0-beta.14.tgz",
-      "integrity": "sha512-OpBOoDma9cDyks6LWNYa6sNmHeW9U+18XA/NlIDvZeP6/+YcmebAtr9cJ89mpiOSYxp/VfOzBExpaHqkyXtVlw==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/form-field/-/form-field-7.0.0-beta.15.tgz",
+      "integrity": "sha512-Ou2Og5pVkktrhPW0c+eA+A6O9WJrpqmOh+ZqekQfixiJRmP13645NRk3qbA0NUoIBb6m+9wJ2KbEoZ0yrHWnaw==",
       "dev": true,
       "requires": {
         "@material/feature-targeting": "^14.0.0",
         "@material/form-field": "^14.0.0",
         "@material/rtl": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "@smui/icon-button": {
@@ -4076,72 +4293,32 @@
       }
     },
     "@smui/line-ripple": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/line-ripple/-/line-ripple-7.0.0-beta.14.tgz",
-      "integrity": "sha512-9BsByyEizUPG7b4VRX3Wahmb300wlJSxgyY1EYVIna1mnKRXwvBp2TKjAnOZ8y8tKhOlfLJXFI8uVoEGnLK8BA==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/line-ripple/-/line-ripple-7.0.0-beta.15.tgz",
+      "integrity": "sha512-tfdEybgQlLiotELlWknLzb5l6pT47uGfMGYzLs5AVf74CU/zAhp8NiicHUUmI95qY5P2z2xHYYpdLTs1wZ5c9A==",
       "dev": true,
       "requires": {
         "@material/line-ripple": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
-      }
-    },
-    "@smui/list": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/list/-/list-7.0.0-beta.14.tgz",
-      "integrity": "sha512-HzHxe360OcnNpbdp6mmcAk98kTks/R4FjlV6mb54HRVfYjMB3ZvzUzKE/kz0BRzkRXFVXQN9llEL+eDASOTA4A==",
-      "dev": true,
-      "requires": {
-        "@material/dom": "^14.0.0",
-        "@material/feature-targeting": "^14.0.0",
-        "@material/list": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "@smui/ripple": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
-      }
-    },
-    "@smui/menu": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/menu/-/menu-7.0.0-beta.14.tgz",
-      "integrity": "sha512-CdHdvy9X+qYTzARD+k3op/j90fSQCKkDINog8Y7O1WNxU6sFIhVTVlQWPq6y94VoOIBENJIsukjpGUuEmjZQZw==",
-      "dev": true,
-      "requires": {
-        "@material/dom": "^14.0.0",
-        "@material/menu": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "@smui/list": "^7.0.0-beta.14",
-        "@smui/menu-surface": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
-      }
-    },
-    "@smui/menu-surface": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/menu-surface/-/menu-surface-7.0.0-beta.14.tgz",
-      "integrity": "sha512-2wo7GXNt6+JRiWjy+ocwnkLaFwRMQ0glJusZl/azPO9qCNyjMCisL2iU9wSGExCkjUnCGutCre0Zb63BwRhiQw==",
-      "dev": true,
-      "requires": {
-        "@material/animation": "^14.0.0",
-        "@material/menu-surface": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "@smui/notched-outline": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/notched-outline/-/notched-outline-7.0.0-beta.14.tgz",
-      "integrity": "sha512-gblu47Jrn6ifEm86FGfkwaR2uG7yyiZgvZb2oxrv/fULFHIVZ5b9hHbHuv3PlDmxT79J+Z2OIxb55dOKxGQ8Ng==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/notched-outline/-/notched-outline-7.0.0-beta.15.tgz",
+      "integrity": "sha512-9oVSIYmb1/GcCFYm1M0xVy4J5/A2Ysa4H6gm3RIL9/ke3F9EmmALmCs1lmtGu4Vwyo0ES5KroW2Tly2SzMfB2g==",
       "dev": true,
       "requires": {
         "@material/notched-outline": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "@smui/floating-label": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/floating-label": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "@smui/paper": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/paper/-/paper-7.0.0-beta.14.tgz",
-      "integrity": "sha512-qz8lge3p0oJIIazTCMOfjdmEeilO5vMlU2bAmsQtbPqqP6v+wV5K+f/zXnSHtziIYd4fjlTW9bgxmkmf7r4uEA==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/paper/-/paper-7.0.0-beta.15.tgz",
+      "integrity": "sha512-qJgu41Gn/5fjhzo9rEhVnYm3U2SL9ECCD1nfmqbRMUzVlaeWrlSwWqJcJSAR6Og2ya8BYBoJetbxUdlLU8X9GA==",
       "dev": true,
       "requires": {
         "@material/elevation": "^14.0.0",
@@ -4149,42 +4326,20 @@
         "@material/shape": "^14.0.0",
         "@material/theme": "^14.0.0",
         "@material/typography": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "@smui/ripple": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.14.tgz",
-      "integrity": "sha512-EQyZIicnJj3mNCXK1PuGQ4zZOdXrhRtcHGJCrTUNjQzltIQai446Y9aRk5PhY3EIWfTYZuWnqaprC6R00EJOKA==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/ripple/-/ripple-7.0.0-beta.15.tgz",
+      "integrity": "sha512-l0c94p60gxbsClH0KzA2meJ2IGHc7ZUMyWqODkLNz7ziUYxk3VZvWf/Y7Ca+64IJj0keCGPMpFauFaJO8h3Gtw==",
       "dev": true,
       "requires": {
         "@material/dom": "^14.0.0",
         "@material/ripple": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
-      }
-    },
-    "@smui/select": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/select/-/select-7.0.0-beta.14.tgz",
-      "integrity": "sha512-pv3xdnbHLYE72qFfTy3Kx/sTsezyHheEdcXNeQ6DKZ9v/2RcJzlQSA/Q/Qj559ZWH1m6XOK9kXk1HjtsaQk6bg==",
-      "dev": true,
-      "requires": {
-        "@material/feature-targeting": "^14.0.0",
-        "@material/ripple": "^14.0.0",
-        "@material/rtl": "^14.0.0",
-        "@material/select": "^14.0.0",
-        "@material/theme": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "@smui/floating-label": "^7.0.0-beta.14",
-        "@smui/line-ripple": "^7.0.0-beta.14",
-        "@smui/list": "^7.0.0-beta.14",
-        "@smui/menu": "^7.0.0-beta.14",
-        "@smui/menu-surface": "^7.0.0-beta.14",
-        "@smui/notched-outline": "^7.0.0-beta.14",
-        "@smui/ripple": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "@smui/snackbar": {
@@ -4204,9 +4359,9 @@
       }
     },
     "@smui/textfield": {
-      "version": "7.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/@smui/textfield/-/textfield-7.0.0-beta.14.tgz",
-      "integrity": "sha512-bFAHuECVrNxeHdLgirkhtzbytZ8WqyV4aOv4pmTm6SB/K8YgdnzKT8DLWzvx3Ma+OkV1E//u2DpvcvnpB+VN4g==",
+      "version": "7.0.0-beta.15",
+      "resolved": "https://registry.npmjs.org/@smui/textfield/-/textfield-7.0.0-beta.15.tgz",
+      "integrity": "sha512-98lGaVJRH3K5aXVUAa8o/8rHRQ/Vwu9q6phupSrPW4BEmEEEezb/fzKExTOgm0c241dy4nDRLkdH9IdtObTA8w==",
       "dev": true,
       "requires": {
         "@material/dom": "^14.0.0",
@@ -4214,12 +4369,12 @@
         "@material/ripple": "^14.0.0",
         "@material/rtl": "^14.0.0",
         "@material/textfield": "^14.0.0",
-        "@smui/common": "^7.0.0-beta.14",
-        "@smui/floating-label": "^7.0.0-beta.14",
-        "@smui/line-ripple": "^7.0.0-beta.14",
-        "@smui/notched-outline": "^7.0.0-beta.14",
-        "@smui/ripple": "^7.0.0-beta.14",
-        "svelte2tsx": "^0.6.15"
+        "@smui/common": "^7.0.0-beta.15",
+        "@smui/floating-label": "^7.0.0-beta.15",
+        "@smui/line-ripple": "^7.0.0-beta.15",
+        "@smui/notched-outline": "^7.0.0-beta.15",
+        "@smui/ripple": "^7.0.0-beta.15",
+        "svelte2tsx": "^0.6.21"
       }
     },
     "@smui/top-app-bar": {
@@ -4437,9 +4592,9 @@
       }
     },
     "ci-info": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
-      "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
       "dev": true
     },
     "cliui": {
@@ -4511,9 +4666,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.0.tgz",
-      "integrity": "sha512-rd4rYZNlF3WuoYuRIDEmbR/ga9CeuWX9U05umAvgrrZoHY4Z++cp/xwPQMvUpBB4Ag6J8KfD80G0zwCyaSxDww==",
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.1.tgz",
+      "integrity": "sha512-qVSq3s+d4+GsqN0teRCJtM6tdEEXyWxjzbhVrCHmBS5ZTM0FS2MOS0D13dUXAWDUN6a+lHI/N1hF9Ytz6iLl9Q==",
       "dev": true
     },
     "cross-spawn": {
@@ -4645,12 +4800,6 @@
         "merge2": "^1.3.0",
         "micromatch": "^4.0.4"
       }
-    },
-    "fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true
     },
     "fastq": {
       "version": "1.15.0",
@@ -4852,16 +5001,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
-    },
-    "isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
     },
     "json-schema-compare": {
       "version": "0.2.2",
@@ -5407,9 +5546,9 @@
       "dev": true
     },
     "svelte-jsonschema-form": {
-      "version": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#d3247a9066399acc032c625a2af4cb99682745fa",
+      "version": "git+ssh://git@github.com/webgme/svelte-jsonschema-form.git#0999ae10bd9907e6867acaf38cfb76011ee9be2e",
       "dev": true,
-      "from": "svelte-jsonschema-form@github:webgme/svelte-jsonschema-form#v0.6.0",
+      "from": "svelte-jsonschema-form@github:webgme/svelte-jsonschema-form#v0.6.4",
       "requires": {
         "@json-schema-tools/dereferencer": "^1.6.1",
         "@json-schema-tools/traverse": "^1.10.1",
@@ -5428,13 +5567,474 @@
         "json-schema-merge-allof": "^0.8.1",
         "patch-package": "^7.0.2",
         "svelte-portal": "^2.2.0"
+      },
+      "dependencies": {
+        "@json-schema-spec/json-pointer": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "@json-schema-tools/dereferencer": {
+          "version": "1.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@json-schema-tools/reference-resolver": "^1.2.5",
+            "@json-schema-tools/traverse": "^1.10.0",
+            "fast-safe-stringify": "^2.1.1"
+          }
+        },
+        "@json-schema-tools/reference-resolver": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@json-schema-spec/json-pointer": "^0.1.2",
+            "isomorphic-fetch": "^3.0.0"
+          }
+        },
+        "@json-schema-tools/traverse": {
+          "version": "1.10.1",
+          "bundled": true,
+          "dev": true
+        },
+        "@material/animation": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/base": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/density": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/dom": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/feature-targeting": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/elevation": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/animation": "^14.0.0",
+            "@material/base": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/feature-targeting": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/floating-label": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/animation": "^14.0.0",
+            "@material/base": "^14.0.0",
+            "@material/dom": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "@material/typography": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/line-ripple": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/animation": "^14.0.0",
+            "@material/base": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/list": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/base": "^14.0.0",
+            "@material/density": "^14.0.0",
+            "@material/dom": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/ripple": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "@material/shape": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "@material/typography": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/menu": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/base": "^14.0.0",
+            "@material/dom": "^14.0.0",
+            "@material/elevation": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/list": "^14.0.0",
+            "@material/menu-surface": "^14.0.0",
+            "@material/ripple": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/menu-surface": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/animation": "^14.0.0",
+            "@material/base": "^14.0.0",
+            "@material/elevation": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "@material/shape": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/notched-outline": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/base": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/floating-label": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "@material/shape": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/ripple": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/animation": "^14.0.0",
+            "@material/base": "^14.0.0",
+            "@material/dom": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/rtl": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/theme": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/select": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/animation": "^14.0.0",
+            "@material/base": "^14.0.0",
+            "@material/density": "^14.0.0",
+            "@material/dom": "^14.0.0",
+            "@material/elevation": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/floating-label": "^14.0.0",
+            "@material/line-ripple": "^14.0.0",
+            "@material/list": "^14.0.0",
+            "@material/menu": "^14.0.0",
+            "@material/menu-surface": "^14.0.0",
+            "@material/notched-outline": "^14.0.0",
+            "@material/ripple": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "@material/shape": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "@material/tokens": "^14.0.0",
+            "@material/typography": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/shape": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/feature-targeting": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/theme": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/feature-targeting": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/tokens": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/elevation": "^14.0.0"
+          }
+        },
+        "@material/typography": {
+          "version": "14.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/feature-targeting": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@smui/common": {
+          "version": "7.0.0-beta.14",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/dom": "^14.0.0",
+            "svelte2tsx": "^0.6.15"
+          }
+        },
+        "@smui/floating-label": {
+          "version": "7.0.0-beta.14",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/floating-label": "^14.0.0",
+            "@smui/common": "^7.0.0-beta.14",
+            "svelte2tsx": "^0.6.15"
+          }
+        },
+        "@smui/line-ripple": {
+          "version": "7.0.0-beta.14",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/line-ripple": "^14.0.0",
+            "@smui/common": "^7.0.0-beta.14",
+            "svelte2tsx": "^0.6.15"
+          }
+        },
+        "@smui/list": {
+          "version": "7.0.0-beta.14",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/dom": "^14.0.0",
+            "@material/feature-targeting": "^14.0.0",
+            "@material/list": "^14.0.0",
+            "@smui/common": "^7.0.0-beta.14",
+            "@smui/ripple": "^7.0.0-beta.14",
+            "svelte2tsx": "^0.6.15"
+          }
+        },
+        "@smui/menu": {
+          "version": "7.0.0-beta.14",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/dom": "^14.0.0",
+            "@material/menu": "^14.0.0",
+            "@smui/common": "^7.0.0-beta.14",
+            "@smui/list": "^7.0.0-beta.14",
+            "@smui/menu-surface": "^7.0.0-beta.14",
+            "svelte2tsx": "^0.6.15"
+          }
+        },
+        "@smui/menu-surface": {
+          "version": "7.0.0-beta.14",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/animation": "^14.0.0",
+            "@material/menu-surface": "^14.0.0",
+            "@smui/common": "^7.0.0-beta.14",
+            "svelte2tsx": "^0.6.15"
+          }
+        },
+        "@smui/notched-outline": {
+          "version": "7.0.0-beta.14",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/notched-outline": "^14.0.0",
+            "@smui/common": "^7.0.0-beta.14",
+            "@smui/floating-label": "^7.0.0-beta.14",
+            "svelte2tsx": "^0.6.15"
+          }
+        },
+        "@smui/ripple": {
+          "version": "7.0.0-beta.14",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/dom": "^14.0.0",
+            "@material/ripple": "^14.0.0",
+            "@smui/common": "^7.0.0-beta.14",
+            "svelte2tsx": "^0.6.15"
+          }
+        },
+        "@smui/select": {
+          "version": "7.0.0-beta.14",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@material/feature-targeting": "^14.0.0",
+            "@material/ripple": "^14.0.0",
+            "@material/rtl": "^14.0.0",
+            "@material/select": "^14.0.0",
+            "@material/theme": "^14.0.0",
+            "@smui/common": "^7.0.0-beta.14",
+            "@smui/floating-label": "^7.0.0-beta.14",
+            "@smui/line-ripple": "^7.0.0-beta.14",
+            "@smui/list": "^7.0.0-beta.14",
+            "@smui/menu": "^7.0.0-beta.14",
+            "@smui/menu-surface": "^7.0.0-beta.14",
+            "@smui/notched-outline": "^7.0.0-beta.14",
+            "@smui/ripple": "^7.0.0-beta.14",
+            "svelte2tsx": "^0.6.15"
+          }
+        },
+        "dedent-js": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "fast-safe-stringify": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "isomorphic-fetch": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "node-fetch": "^2.6.1",
+            "whatwg-fetch": "^3.4.1"
+          }
+        },
+        "lower-case": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "tslib": "^2.0.3"
+          }
+        },
+        "no-case": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lower-case": "^2.0.2",
+            "tslib": "^2.0.3"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "pascal-case": {
+          "version": "3.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "no-case": "^3.0.4",
+            "tslib": "^2.0.3"
+          }
+        },
+        "svelte-portal": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "svelte2tsx": {
+          "version": "0.6.19",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dedent-js": "^1.0.1",
+            "pascal-case": "^3.1.1"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "tslib": {
+          "version": "2.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "whatwg-fetch": {
+          "version": "3.6.2",
+          "bundled": true,
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
       }
-    },
-    "svelte-portal": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/svelte-portal/-/svelte-portal-2.2.0.tgz",
-      "integrity": "sha512-jhtZWtD6cUE2nMw46dJ5VXWYiqnER+JH+V/BmNBQ5fNP/YdsJCpJi+DemUy9msklqGb0f+wLhJPBtKHLWQvzjg==",
-      "dev": true
     },
     "svelte-preprocess": {
       "version": "5.0.4",
@@ -5461,9 +6061,9 @@
       }
     },
     "svelte2tsx": {
-      "version": "0.6.19",
-      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.19.tgz",
-      "integrity": "sha512-h3b5OtcO8zyVL/RiB2zsDwCopeo/UH+887uyhgb2mjnewOFwiTxu+4IGuVwrrlyuh2onM2ktfUemNrNmQwXONQ==",
+      "version": "0.6.23",
+      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.6.23.tgz",
+      "integrity": "sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==",
       "dev": true,
       "requires": {
         "dedent-js": "^1.0.1",
@@ -5582,12 +6182,6 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true
     },
-    "whatwg-fetch": {
-      "version": "3.6.17",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.17.tgz",
-      "integrity": "sha512-c4ghIvG6th0eudYwKZY5keb81wtFz9/WeAHAoy8+r18kcWlitUIrmGFQ2rWEl4UCKUilD3zCLHOIPheHx5ypRQ==",
-      "dev": true
-    },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -5637,9 +6231,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.3.tgz",
+      "integrity": "sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==",
       "dev": true
     },
     "yargs": {

--- a/src/routers/TagCreator/form/package.json
+++ b/src/routers/TagCreator/form/package.json
@@ -24,7 +24,7 @@
     "smui-theme": "^7.0.0-beta.14",
     "svelte": "^4.1.2",
     "svelte-check": "^3.4.6",
-    "svelte-jsonschema-form": "github:webgme/svelte-jsonschema-form#v0.6.0",
+    "svelte-jsonschema-form": "github:webgme/svelte-jsonschema-form#v0.6.4",
     "svelte-preprocess": "^5.0.4",
     "tslib": "^2.6.1",
     "typescript": "^5.1.6",

--- a/src/routers/TagCreator/form/src/App.svelte
+++ b/src/routers/TagCreator/form/src/App.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import 'svelte-jsonschema-form/theme/default';
   import SchemaForm, { type ValidationError, type JSONSchema7 } from 'svelte-jsonschema-form';
   import TopAppBar, { Row, Section, Title } from "@smui/top-app-bar";
   import Button, { Label } from '@smui/button';

--- a/src/routers/TagCreator/form/src/theme/_smui-theme.scss
+++ b/src/routers/TagCreator/form/src/theme/_smui-theme.scss
@@ -1,5 +1,3 @@
-@use 'sass:color';
-
 @use '@material/theme/color-palette';
 
 // Svelte Colors!
@@ -17,13 +15,9 @@ body {
   background-color: theme.$surface;
   color: theme.$on-surface;
   font-family: Roboto, sans-serif;
+  --mdc-theme-primary: #{theme.$primary};
+  --mdc-theme-secondary: #{theme.$secondary};
+  --mdc-theme-surface: #{theme.$surface};
+  --mdc-theme-background: #{theme.$background};
+  --mdc-theme-error: #{theme.$error};
 }
-
-a {
-  color: #40b3ff;
-}
-a:visited {
-  color: color.scale(#40b3ff, $lightness: -35%);
-}
-
-@import 'svelte-jsonschema-form/src/theme/custom'


### PR DESCRIPTION
updates the svelte-jsonschema-form dependency version

- remove svelte-jsonschema-form dependency  from Insights dashboard (note being used)
- fixes issue with svelte-jsonschema-form's patched packages not being patched
- import default them in tag form