### PR TITLE
Remove `additionalProperties` from enum field. Fix #479

### DIFF
--- a/src/common/JSONSchemaExporter.ts
+++ b/src/common/JSONSchemaExporter.ts
@@ -60,7 +60,6 @@ interface UriFieldSchema extends BaseFieldSchema {
 }
 interface EnumFieldSchema extends BaseFieldSchema {
   type: "object";
-  additionalProperties: false;
   anyOf: CompoundFieldSchema[];
 }
 interface CompoundFieldSchema extends BaseFieldSchema {
@@ -427,7 +426,6 @@ export default class JSONSchemaExporter {
         const fieldSchema: EnumFieldSchema = {
           title: name,
           type: "object",
-          additionalProperties: false,
           anyOf,
           // TODO: make the name a required field
         };

--- a/test/common/JSONSchemaExporter.spec.js
+++ b/test/common/JSONSchemaExporter.spec.js
@@ -1,0 +1,58 @@
+describe("JSONSchemaExporter", function () {
+  const testFixture = require("../globals");
+  const JSONSchemaExporter = require("../../build/common/JSONSchemaExporter").default;
+  const Ajv = require("ajv");
+  const ajv = new Ajv();
+  const assert = require("assert");
+  const Utils = require("../Utils");
+  let project, gmeAuth, storage, commitHash, core;
+
+  before(async function () {
+    this.timeout(7500);
+    const params = await Utils.initializeProject(
+      "JSONSchemaExporter",
+      "test",
+    );
+    gmeAuth = params.gmeAuth;
+    storage = params.storage;
+    commitHash = params.commitHash;
+    core = params.core;
+    project = params.project;
+  });
+
+  after(async function () {
+    await storage.closeDatabase();
+    await gmeAuth.unload();
+  });
+
+  describe("enum", function () {
+    it("should validate basic enum", async function () {
+      const tags = {Subject: {Sex: {value: {Male: {}}}}};
+      const errors = await getErrors(tags);
+      assert(!errors);
+    });
+  });
+
+  async function getErrors(tags, onlyReleased=true) {
+    const root = await Utils.getNewRootNode(project, commitHash, core);
+    const exporter = JSONSchemaExporter.from(core, root);
+    const taxonomy = (await core.loadChildren(root))
+      .find(n => {
+        const metaType = core.getMetaType(n);
+        return metaType && core.getAttribute(metaType, 'name') === 'Taxonomy';
+      });
+
+    const name = core.getAttribute(taxonomy, 'name');
+    const vocabs = await Promise.all(
+      Object.keys(tags).map(async vocabName => {
+        const allVocabs = await core.loadChildren(taxonomy);
+        return allVocabs.find(v => core.getAttribute(v, 'name') === vocabName);
+      })
+    );
+    const {schema} = await exporter.getVocabSchemas(vocabs, name, onlyReleased);
+
+    const validate = ajv.compile(schema);
+    validate(tags);
+    return validate.errors;
+  }
+});

--- a/test/common/JSONSchemaExporter.spec.js
+++ b/test/common/JSONSchemaExporter.spec.js
@@ -1,6 +1,7 @@
 describe("JSONSchemaExporter", function () {
   const testFixture = require("../globals");
-  const JSONSchemaExporter = require("../../build/common/JSONSchemaExporter").default;
+  const JSONSchemaExporter =
+    require("../../build/common/JSONSchemaExporter").default;
   const Ajv = require("ajv");
   const ajv = new Ajv();
   const assert = require("assert");
@@ -27,29 +28,35 @@ describe("JSONSchemaExporter", function () {
 
   describe("enum", function () {
     it("should validate basic enum", async function () {
-      const tags = {Subject: {Sex: {value: {Male: {}}}}};
+      const tags = { Subject: { Sex: { value: { Male: {} } } } };
       const errors = await getErrors(tags);
       assert(!errors);
     });
   });
 
-  async function getErrors(tags, onlyReleased=true) {
+  async function getErrors(tags, onlyReleased = true) {
     const root = await Utils.getNewRootNode(project, commitHash, core);
     const exporter = JSONSchemaExporter.from(core, root);
     const taxonomy = (await core.loadChildren(root))
-      .find(n => {
+      .find((n) => {
         const metaType = core.getMetaType(n);
-        return metaType && core.getAttribute(metaType, 'name') === 'Taxonomy';
+        return metaType && core.getAttribute(metaType, "name") === "Taxonomy";
       });
 
-    const name = core.getAttribute(taxonomy, 'name');
+    const name = core.getAttribute(taxonomy, "name");
     const vocabs = await Promise.all(
-      Object.keys(tags).map(async vocabName => {
+      Object.keys(tags).map(async (vocabName) => {
         const allVocabs = await core.loadChildren(taxonomy);
-        return allVocabs.find(v => core.getAttribute(v, 'name') === vocabName);
-      })
+        return allVocabs.find((v) =>
+          core.getAttribute(v, "name") === vocabName
+        );
+      }),
     );
-    const {schema} = await exporter.getVocabSchemas(vocabs, name, onlyReleased);
+    const { schema } = await exporter.getVocabSchemas(
+      vocabs,
+      name,
+      onlyReleased,
+    );
 
     const validate = ajv.compile(schema);
     validate(tags);


### PR DESCRIPTION
This isn't needed since we have it on the children. Since the parent
doesn't define any properties, this actually restricts the field from
being set entirely!
