### PR TITLE
Add TEST_TARGETS env var for selectively building test files

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -176,7 +176,7 @@ if (process.env.NODE_ENV === "test") {
     typescript(tsconfig),
     json(),
   ];
-  const configs = tsFiles
+  let configs = tsFiles
     .map((filename) => ({
       input: filename,
       external,
@@ -201,10 +201,16 @@ if (process.env.NODE_ENV === "test") {
     configs[0].plugins = configs[0].plugins.concat(copy({ targets }));
   }
 
+  if (process.env.TEST_TARGETS) {
+    const inputs = process.env.TEST_TARGETS.split(',');
+    configs = configs.filter(cfg => inputs.find(name => cfg.input.includes(name)));
+  }
+
   console.log(`About to build ${configs.length} files for testing:`);
   console.log(
     configs.map((cfg) => cfg.output.file).map((name) => "\t" + name).join("\n"),
   );
+
   buildRouters.push(...configs);
 }
 

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -202,8 +202,10 @@ if (process.env.NODE_ENV === "test") {
   }
 
   if (process.env.TEST_TARGETS) {
-    const inputs = process.env.TEST_TARGETS.split(',');
-    configs = configs.filter(cfg => inputs.find(name => cfg.input.includes(name)));
+    const inputs = process.env.TEST_TARGETS.split(",");
+    configs = configs.filter((cfg) =>
+      inputs.find((name) => cfg.input.includes(name))
+    );
   }
 
   console.log(`About to build ${configs.length} files for testing:`);


### PR DESCRIPTION
This PR adds an optional environment variable, `TEST_TARGETS`. If set (and building in test mode), the build script will whitelist the test files built based on if they contain the given substring(s).