### PR TITLE
Add index attribute back to AppendResult. Close #512

### DIFF
--- a/src/routers/Search/adapters/MongoDB/index.ts
+++ b/src/routers/Search/adapters/MongoDB/index.ts
@@ -389,7 +389,7 @@ export default class MongoAdapter implements Adapter {
       contentId,
       zip(filenames, fileIds),
     );
-    return new AppendResult(contentId, files);
+    return new AppendResult(contentId, files, res.index);
   }
 
   private getFileUploadReqs(

--- a/src/routers/Search/adapters/PDP/index.ts
+++ b/src/routers/Search/adapters/PDP/index.ts
@@ -460,7 +460,7 @@ export default class PDP implements Adapter {
       return new UploadRequest(name, params);
     });
 
-    return new AppendResult(`${index}_0`, files);
+    return new AppendResult(`${index}_0`, files, index);
   }
 
   // TODO: this should probably take a reservation

--- a/src/routers/Search/adapters/common/AppendResult.ts
+++ b/src/routers/Search/adapters/common/AppendResult.ts
@@ -1,9 +1,18 @@
 export class AppendResult {
   id: string;
   files: UploadRequest[];
+  /**
+   * This has been deprecated in favor of "id" since this attribute leaks the concept of an "index" from PDP.
+   * The goal is to move away from these PDP-specific concepts rather than bake these concepts into every
+   * supported storage adapter.
+   * 
+   * @deprecated
+   */
+  index: number;
 
-  constructor(id: string, files: UploadRequest[]) {
+  constructor(id: string, files: UploadRequest[], index: number) {
     this.id = id;
+    this.index = index;
     this.files = files;
   }
 }

--- a/src/routers/Search/adapters/common/AppendResult.ts
+++ b/src/routers/Search/adapters/common/AppendResult.ts
@@ -5,7 +5,7 @@ export class AppendResult {
    * This has been deprecated in favor of "id" since this attribute leaks the concept of an "index" from PDP.
    * The goal is to move away from these PDP-specific concepts rather than bake these concepts into every
    * supported storage adapter.
-   * 
+   *
    * @deprecated
    */
   index: number;


### PR DESCRIPTION
This PR adds the `index` attribute (marked as deprecated) back to the `AppendResult`.

@yogeshVU
