### PR TITLE
In Dashboard, display and add button to copy repository ID to clipboard

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,8 @@
       "src/routers/Insights/dashboard/public/echarts.min.js",
       "src/routers/Insights/dashboard/src/components/echarts.min.js",
       "lib/react-dom.production.min.js",
-      "lib/react.production.min.js"
+      "lib/react.production.min.js",
+      "build"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "users": "node ./node_modules/webgme-engine/src/bin/usermanager.js",
     "clean_up": "node ./node_modules/webgme-engine/src/bin/clean_up.js",
     "typecheck": "tsc --noEmit",
+    "lint": "deno fmt --config deno.json",
     "build": "rollup -c",
     "prepublish": "husky install",
     "prepare-docker": "node scripts/prepare-docker.js",

--- a/src/routers/Search/dashboard/src/App.svelte
+++ b/src/routers/Search/dashboard/src/App.svelte
@@ -8,10 +8,12 @@
     encodeQueryParams,
   } from "./Utils";
   import Textfield from "@smui/textfield";
+  import IconButton from "@smui/icon-button";
   import { SvelteToast, SvelteToastOptions, toast } from "@zerodevx/svelte-toast";
   /*import Chip from "@smui/chips";*/
   import List, {
     Item,
+    Meta,
     Text,
     PrimaryText,
     SecondaryText,
@@ -489,8 +491,19 @@
               >
                 <Text>
                   <PrimaryText>{item.displayName}</PrimaryText>
-                  <SecondaryText />
+                  <SecondaryText>{item.id}</SecondaryText>
                 </Text>
+                <Meta>
+                    <IconButton
+                      on:click$stopPropagation={() => {
+                        navigator.clipboard.writeText(item.id);
+                        displayMessage(`ID copied to Clipboard`);
+                      }}
+                      class="material-icons"
+                      size="mini"
+                      title="Copy ID to Clipboard"
+                    >content_copy</IconButton>
+                  </Meta>
               </Item>
             {/each}
           </List>

--- a/src/routers/Search/dashboard/src/components/AppHeader.svelte
+++ b/src/routers/Search/dashboard/src/components/AppHeader.svelte
@@ -28,12 +28,14 @@
       <IconButton
         class="material-icons"
         aria-label="Upload dataset"
+        title="Upload dataset"
         ripple={false}
         on:click={createArtifact}>file_upload
       </IconButton>
       <IconButton
         class="material-icons"
         aria-label="Edit taxonomy"
+        title="Edit taxonomy"
         ripple={false}
         on:click={openEditor}>open_in_new
       </IconButton>


### PR DESCRIPTION
![image](https://github.com/webgme/webgme-taxonomy/assets/6518904/9167aff3-2428-4614-9ec6-d49e3cb426db)


Fixes #511 