### PR TITLE
Fix onlyReleased flag not respected at JSONSchema export route

### DIFF
--- a/src/routers/JSONSchema/JSONSchema.ts
+++ b/src/routers/JSONSchema/JSONSchema.ts
@@ -64,7 +64,7 @@ function initialize(middlewareOpts: MiddlewareOptions) {
       request: Request,
       response: Response,
     ) {
-      const onlyReleased = request.params.hasOwnProperty("onlyReleased");
+      const onlyReleased = request.query.hasOwnProperty("onlyReleased");
       const { root, core, contentType } = gmeContext;
       const exporter = JSONSchemaExporter.from(core, root);
       const vocabularies = await Utils.getVocabulariesFor(core, contentType);


### PR DESCRIPTION
```
http://localhost:8080/routers/JSONSchema/guest%2BTheTaxonomy/branch/master/%2FP%2Fa/schema.json?onlyReleased
```

Note that even though `onlyReleased=true` works too, the above is preferred as `onlyReleased=false` is treated as a true (simply omit the flag to get the negated behavior).