### PR TITLE
Fixes #539 account for uploadDataFiles being null in type and handle

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,6 @@ webgme.addToRequireJsPaths(gmeConfig);
 
 myServer = new webgme.standaloneServer(gmeConfig);
 myServer.start(function (err) {
-  console.log(err);
-  //console.log('server up');
+  if (err) console.log(err);
+  // console.log('server started');
 });

--- a/src/routers/Search/adapters/PDP/index.ts
+++ b/src/routers/Search/adapters/PDP/index.ts
@@ -454,11 +454,13 @@ export default class PDP implements Adapter {
     );
 
     // TODO: refactor this...
-    const files = result.uploadDataFiles.files.map((file) => {
-      const name = PDP.getOriginalFilePath(file.name);
-      const params = new UploadParams(file.sasUrl, "PUT", UPLOAD_HEADERS);
-      return new UploadRequest(name, params);
-    });
+    const files = result.uploadDataFiles === null
+      ? []
+      : result.uploadDataFiles.files.map((file) => {
+        const name = PDP.getOriginalFilePath(file.name);
+        const params = new UploadParams(file.sasUrl, "PUT", UPLOAD_HEADERS);
+        return new UploadRequest(name, params);
+      });
 
     return new AppendResult(`${index}_0`, files, index);
   }

--- a/src/routers/Search/adapters/PDP/types.ts
+++ b/src/routers/Search/adapters/PDP/types.ts
@@ -62,7 +62,7 @@ export interface LatestMetadata {
 export interface AppendObservationResponse extends Observation {
   uploadDataFiles: {
     files: UploadDataFile[];
-  };
+  } | null;
 }
 
 export interface UploadDataFile {


### PR DESCRIPTION
This response does not have to contain the uploadDataFiles here:
https://leappremonitiondev.azurewebsites.net/index.html?urls.primaryName=v3%20API#/Process/post_v3_Process_AppendObservation

The TS type now accounts for it and it is handled where used.