### PR TITLE
Add URI support for content-type-storage-hosts and repositories

### DIFF
--- a/src/common/JSONSchemaExporter.ts
+++ b/src/common/JSONSchemaExporter.ts
@@ -58,6 +58,7 @@ interface TextFieldSchema extends BaseFieldSchema {
 }
 interface UriFieldSchema extends BaseFieldSchema {
   type: "string";
+  format: "uri";
   pattern: string;
   default?: string;
 }
@@ -434,6 +435,7 @@ export default class JSONSchemaExporter {
         const fieldSchema: UriFieldSchema = {
           title: name,
           type: "string",
+          format: "uri",
           pattern: Pattern.exact(Pattern.anyIn(
             ...StorageAdapters.getUriPatterns(),
           )),

--- a/src/routers/Dashboard/ContextFacade.ts
+++ b/src/routers/Dashboard/ContextFacade.ts
@@ -3,7 +3,7 @@ import { isTypeOf } from "../Search/adapters";
 import { HostUri } from "../Search/adapters/PDP";
 
 export default class ContextFacade {
-  constructor(protected context: GmeContext) { }
+  constructor(protected context: GmeContext) {}
 
   async getContentTypeNodes() {
     const { core, root } = this.context;
@@ -30,17 +30,19 @@ export default class ContextFacade {
 
   async getHostUriToNodePath() {
     const { core } = this.context;
-    const result: { [hostId: string]: string; } = {};
+    const result: { [hostId: string]: string } = {};
     const contentTypeNodes = await this.getContentTypeNodes();
 
     for (const contentTypeNode of contentTypeNodes) {
       const path = core.getPath(contentTypeNode);
-      const storageNode = (await core.loadChildren(contentTypeNode)).find((child) =>
-        isTypeOf(core, child, "Storage")
-      );
+      const storageNode = (await core.loadChildren(contentTypeNode)).find((
+        child,
+      ) => isTypeOf(core, child, "Storage"));
 
       if (!storageNode) {
-        console.warn('Storage node missing for contentTypeNode at [' + path + ']');
+        console.warn(
+          "Storage node missing for contentTypeNode at [" + path + "]",
+        );
         continue;
       }
 
@@ -55,26 +57,35 @@ export default class ContextFacade {
         let uri = core.getAttribute(storageNode, "URI") as string;
         const collection = core.getAttribute(storageNode, "collection");
         if (!uri || !collection) {
-          console.warn('Storage node misses mongo attributes for content-type at [' + path + ']');
+          console.warn(
+            "Storage node misses mongo attributes for content-type at [" +
+              path + "]",
+          );
           continue;
         }
 
-        uri = uri.endsWith('/') ? uri : uri + '/';
+        uri = uri.endsWith("/") ? uri : uri + "/";
 
         result[uri + collection] = path;
       } else if (adapterName === "pdp") {
         let url = core.getAttribute(storageNode, "URL") as string;
         const processType = core.getAttribute(storageNode, "processType");
         if (!url || !processType) {
-          console.warn('Storage node misses pdp attributes for content-type at [' + path + ']');
+          console.warn(
+            "Storage node misses pdp attributes for content-type at [" + path +
+              "]",
+          );
           continue;
         }
 
-        url = url.endsWith('/') ? url : url + '/';
+        url = url.endsWith("/") ? url : url + "/";
 
         result[HostUri.hostUrlToHostUri(url + processType)] = path;
       } else {
-        console.warn('Storage node has unexpected adpter type [' + adapterName + '] for content-type at [' + path + ']');
+        console.warn(
+          "Storage node has unexpected adpter type [" + adapterName +
+            "] for content-type at [" + path + "]",
+        );
         continue;
       }
     }

--- a/src/routers/Dashboard/ContextFacade.ts
+++ b/src/routers/Dashboard/ContextFacade.ts
@@ -1,7 +1,9 @@
 import type { GmeContext } from "../../common/types";
+import { isTypeOf } from "../Search/adapters";
+import { HostUri } from "../Search/adapters/PDP";
 
 export default class ContextFacade {
-  constructor(protected context: GmeContext) {}
+  constructor(protected context: GmeContext) { }
 
   async getContentTypeNodes() {
     const { core, root } = this.context;
@@ -24,5 +26,59 @@ export default class ContextFacade {
         path: core.getPath(node),
       })),
     };
+  }
+
+  async getHostUriToNodePath() {
+    const { core } = this.context;
+    const result: { [hostId: string]: string; } = {};
+    const contentTypeNodes = await this.getContentTypeNodes();
+
+    for (const contentTypeNode of contentTypeNodes) {
+      const path = core.getPath(contentTypeNode);
+      const storageNode = (await core.loadChildren(contentTypeNode)).find((child) =>
+        isTypeOf(core, child, "Storage")
+      );
+
+      if (!storageNode) {
+        console.warn('Storage node missing for contentTypeNode at [' + path + ']');
+        continue;
+      }
+
+      const adapterType = core.getAttribute(
+        core.getMetaType(storageNode),
+        "name",
+      );
+
+      const adapterName = adapterType?.toString().toLowerCase();
+
+      if (adapterName === "mongodb") {
+        let uri = core.getAttribute(storageNode, "URI") as string;
+        const collection = core.getAttribute(storageNode, "collection");
+        if (!uri || !collection) {
+          console.warn('Storage node misses mongo attributes for content-type at [' + path + ']');
+          continue;
+        }
+
+        uri = uri.endsWith('/') ? uri : uri + '/';
+
+        result[uri + collection] = path;
+      } else if (adapterName === "pdp") {
+        let url = core.getAttribute(storageNode, "URL") as string;
+        const processType = core.getAttribute(storageNode, "processType");
+        if (!url || !processType) {
+          console.warn('Storage node misses pdp attributes for content-type at [' + path + ']');
+          continue;
+        }
+
+        url = url.endsWith('/') ? url : url + '/';
+
+        result[HostUri.hostUrlToHostUri(url + processType)] = path;
+      } else {
+        console.warn('Storage node has unexpected adpter type [' + adapterName + '] for content-type at [' + path + ']');
+        continue;
+      }
+    }
+
+    return result;
   }
 }

--- a/src/routers/Dashboard/Dashboard.ts
+++ b/src/routers/Dashboard/Dashboard.ts
@@ -103,45 +103,44 @@ export function initialize(middlewareOpts: MiddlewareOptions) {
     "resolve-url",
     async function resolveUrl(gmeContext, req, res) {
       const { uri } = req.body;
-      // FIXME: This doesn't work for repositories..
-      const [repoId, contentId] = StorageAdapter.resolveUri(uri);
-      logger.info(
-        `uri="${uri}", with repoId="${repoId}", contentId="${contentId}"`,
-      );
-      // Grab all contentTypes for the project..
-      const projectInfo = await (new ContextFacade(gmeContext))
-        .getProjectInfo();
+      let uriPieces: [string, string, string];
 
-      let url: string | null = null;
-
-      for (const { name, path } of projectInfo.contentTypes) {
-        logger.info(`At content type ${name} ${path}`);
-        const contentContext = await getContentContext(gmeContext, path);
-        const storage = await StorageAdapter.from(
-          contentContext,
-          req,
-          middlewareOpts.gmeConfig,
-        );
-        // List all the repos for each such..
-        for (const repo of await storage.listRepos()) {
-          if (repo.id === repoId) {
-            logger.info(`found matching repository: ${JSON.stringify(repo)}`);
-            // original: /routers/Dashboard/guest%2BmongoPipeline/branch/master/resolve-url
-            // url: /routers/Search/guest%2BmongoPipeline/branch/master/%2FA/static/index.html?repoId=6617fab6596a7edfc2fb9cff&contentId=1_1
-            url =
-              `${
-                req.originalUrl.split("?")[0].replace(/Dashboard/, "Search")
-                  .split("/").slice(0, -1).join("/")
-              }` +
-              `/${
-                encodeURIComponent(path)
-              }/static/index.html?repoId=${repoId}&contentId=${contentId}`;
-            break;
-          }
-        }
+      try {
+        uriPieces = StorageAdapter.resolveUri(uri);
+      } catch (err) {
+        logger.error(err);
+        res.sendStatus(400);
+        return;
       }
 
-      // TODO: Check that this works behind secure proxy..
+      const [hostId, repoId, contentId] = uriPieces;
+
+      logger.info(`uri="${uri}", with hostId="${hostId}", repoId="${repoId}", contentId="${contentId}"`);
+
+      // Grab all contentTypes for the project..
+      const hostUriToPath = await (new ContextFacade(gmeContext)).getHostUriToNodePath();
+      // logger.info(JSON.stringify(hostUriToPath, null, 2));
+      const path = hostUriToPath[hostId];
+
+      if (!path) {
+        logger.error('Could not find matching node for ' + hostId);
+        res.sendStatus(404);
+        return;
+      }
+
+      // original: /routers/Dashboard/guest%2BmongoPipeline/branch/master/resolve-url
+      // url: /routers/Search/guest%2BmongoPipeline/branch/master/%2FA/static/index.html?repoId=6617fab6596a7edfc2fb9cff&contentId=1_1
+      let url = `${req.originalUrl.split("?")[0].replace(/Dashboard/, "Search").split("/").slice(0, -1).join("/")}` +
+        `/${encodeURIComponent(path)}/static/index.html`;
+
+      if (repoId) {
+        url += `?repoId=${repoId}`;
+      }
+
+      if (contentId) {
+        url += `&contentId=${contentId}`;
+      }
+
       res.json({ host: `${req.protocol}://${req.get("host")}`, url });
     },
     { method: "post" },
@@ -227,7 +226,7 @@ export function initialize(middlewareOpts: MiddlewareOptions) {
                   if (!parentId || !id) {
                     throw new Error(
                       "content missing id or parentId " +
-                        JSON.stringify({ parentId, id }),
+                      JSON.stringify({ parentId, id }),
                     );
                   }
                   await gremlinAdapter.create(

--- a/src/routers/Dashboard/Dashboard.ts
+++ b/src/routers/Dashboard/Dashboard.ts
@@ -115,22 +115,30 @@ export function initialize(middlewareOpts: MiddlewareOptions) {
 
       const [hostId, repoId, contentId] = uriPieces;
 
-      logger.info(`uri="${uri}", with hostId="${hostId}", repoId="${repoId}", contentId="${contentId}"`);
+      logger.info(
+        `uri="${uri}", with hostId="${hostId}", repoId="${repoId}", contentId="${contentId}"`,
+      );
 
       // Grab all contentTypes for the project..
-      const hostUriToPath = await (new ContextFacade(gmeContext)).getHostUriToNodePath();
+      const hostUriToPath = await (new ContextFacade(gmeContext))
+        .getHostUriToNodePath();
       // logger.info(JSON.stringify(hostUriToPath, null, 2));
       const path = hostUriToPath[hostId];
 
       if (!path) {
-        logger.error('Could not find matching node for ' + hostId);
+        logger.error("Could not find matching node for " + hostId);
         res.sendStatus(404);
         return;
       }
 
       // original: /routers/Dashboard/guest%2BmongoPipeline/branch/master/resolve-url
       // url: /routers/Search/guest%2BmongoPipeline/branch/master/%2FA/static/index.html?repoId=6617fab6596a7edfc2fb9cff&contentId=1_1
-      let url = `${req.originalUrl.split("?")[0].replace(/Dashboard/, "Search").split("/").slice(0, -1).join("/")}` +
+      let url =
+        `${
+          req.originalUrl.split("?")[0].replace(/Dashboard/, "Search").split(
+            "/",
+          ).slice(0, -1).join("/")
+        }` +
         `/${encodeURIComponent(path)}/static/index.html`;
 
       if (repoId) {
@@ -226,7 +234,7 @@ export function initialize(middlewareOpts: MiddlewareOptions) {
                   if (!parentId || !id) {
                     throw new Error(
                       "content missing id or parentId " +
-                      JSON.stringify({ parentId, id }),
+                        JSON.stringify({ parentId, id }),
                     );
                   }
                   await gremlinAdapter.create(

--- a/src/routers/Search/TaskQueue.ts
+++ b/src/routers/Search/TaskQueue.ts
@@ -80,7 +80,7 @@ export class DownloadTask implements Runnable<FilePath> {
 
     const uniqNames = names.reduce(
       (names, name) => names.concat(namer.unique(name)),
-      <string[]>[],
+      <string[]> [],
     );
 
     // Write data to files

--- a/src/routers/Search/TaskQueue.ts
+++ b/src/routers/Search/TaskQueue.ts
@@ -80,7 +80,7 @@ export class DownloadTask implements Runnable<FilePath> {
 
     const uniqNames = names.reduce(
       (names, name) => names.concat(namer.unique(name)),
-      <string[]> [],
+      <string[]>[],
     );
 
     // Write data to files
@@ -98,7 +98,7 @@ export class DownloadTask implements Runnable<FilePath> {
           uri,
           this.config,
         );
-        const [repoId, id] = storage.resolveUri(uri);
+        const [_, repoId, id] = storage.resolveUri(uri);
         console.log("getting file streams:", { uri, repoId, id });
         const streamDict = await storage.getFileStreams(repoId, id);
 

--- a/src/routers/Search/adapters/MongoDB/index.ts
+++ b/src/routers/Search/adapters/MongoDB/index.ts
@@ -592,8 +592,8 @@ export default class MongoAdapter implements Adapter {
   static resolveUri(uri: string): [string, string, string] {
     const chunks = uri.split("/");
     let host: string;
-    let repo: string = '';
-    let content: string = '';
+    let repo: string = "";
+    let content: string = "";
 
     if (RegExp(contentPattern).test(uri)) {
       content = chunks.pop() as string;

--- a/src/routers/Search/adapters/MongoDB/index.ts
+++ b/src/routers/Search/adapters/MongoDB/index.ts
@@ -47,6 +47,10 @@ import {
   DeletedContentError,
 } from "../../../../common/UserError";
 
+const hostPattern = `mongoDoc://${Pattern.URL}/([a-zA-Z0-9_]+/)?[a-zA-Z_]+`;
+const repoPattern = hostPattern + "/[a-f0-9]{24}";
+const contentPattern = repoPattern + "/[0-9]+";
+
 const defaultMongoUri = gmeConfig.mongo.uri;
 const defaultClient = new MongoClient(defaultMongoUri);
 
@@ -581,30 +585,39 @@ export default class MongoAdapter implements Adapter {
     return `mongoDoc://${hostAddr}/${collection}`;
   }
 
-  resolveUri(uri: string): [string, string] {
+  resolveUri(uri: string): [string, string, string] {
     return MongoAdapter.resolveUri(uri);
   }
 
-  static resolveUri(uri: string): [string, string] {
+  static resolveUri(uri: string): [string, string, string] {
     const chunks = uri.split("/");
-    let content = chunks.pop() as string;
-    if (!content.includes("_")) {
-      // Fix for first versions that only includes the index and no version
-      content += "_0";
+    let host: string;
+    let repo: string = '';
+    let content: string = '';
+
+    if (RegExp(contentPattern).test(uri)) {
+      content = chunks.pop() as string;
+      if (!content.includes("_")) {
+        // Fix for first versions that only includes the index and no version
+        content += "_0";
+      }
+      repo = chunks.pop() as string;
+    } else if (RegExp(repoPattern).test(uri)) {
+      repo = chunks.pop() as string;
+    } else if (!RegExp(hostPattern).test(uri)) {
+      throw new Error(`No valid uri provided: ${uri}`);
     }
 
-    const repo = chunks.pop() as string;
-    return [repo, content];
+    host = chunks.join("/");
+
+    return [host, repo, content];
   }
 
   static getUriPatterns(): string[] {
-    const hostPattern =
-      `mongoDoc://${Pattern.URL}/([a-zA-Z0-9_]+/)?[a-zA-Z_]+/`;
-    const repoPattern = "[a-f0-9]{24}";
-    const contentPattern = "[0-9]+";
     return [
-      hostPattern + repoPattern,
-      hostPattern + repoPattern + "/" + contentPattern,
+      hostPattern,
+      repoPattern,
+      contentPattern,
     ];
   }
 }

--- a/src/routers/Search/adapters/PDP/index.ts
+++ b/src/routers/Search/adapters/PDP/index.ts
@@ -990,7 +990,7 @@ class ObservationReservation implements ContentReservation {
     this.index = index;
     this.version = version;
     this.uri = uri;
-    this.contentId = `${index}_${version} `;
+    this.contentId = `${index}_${version}`;
   }
 }
 
@@ -1015,8 +1015,8 @@ class ObservationUpdateReservation implements UpdateReservation {
     this.version = version;
 
     this.repoId = processId.toString();
-    this.contentId = `${index}_${version} `;
-    this.targetContentId = `${index}_${targetVersion} `;
+    this.contentId = `${index}_${version}`;
+    this.targetContentId = `${index}_${targetVersion}`;
     this.uri = uri;
   }
 }

--- a/src/routers/Search/adapters/PDP/index.ts
+++ b/src/routers/Search/adapters/PDP/index.ts
@@ -898,8 +898,8 @@ export default class PDP implements Adapter {
   static resolveUri(uri: string): [string, string, string] {
     const chunks = uri.split("/");
     let host: string;
-    let repo: string = '';
-    let content: string = '';
+    let repo: string = "";
+    let content: string = "";
 
     if (RegExp(contentPattern).test(uri)) {
       const version = chunks.pop() as string;

--- a/src/routers/Search/adapters/common/types.d.ts
+++ b/src/routers/Search/adapters/common/types.d.ts
@@ -75,7 +75,7 @@ export interface Adapter {
   /**
    * Convert a URI to a repo and content ID.
    */
-  resolveUri(uri: string): [string, string];
+  resolveUri(uri: string): [string, string, string];
   /*
    * RAII-style reservations for uploading data
    */
@@ -130,7 +130,7 @@ export interface AdapterStatic<A extends Adapter> {
     uri: string,
   ): Promise<A>;
   getUriPatterns(): string[];
-  resolveUri(uri: string): [string, string];
+  resolveUri(uri: string): [string, string, string];
 }
 
 export interface Artifact {

--- a/src/routers/Search/adapters/index.ts
+++ b/src/routers/Search/adapters/index.ts
@@ -123,7 +123,7 @@ export default class Adapters {
     ].flat();
   }
 
-  static resolveUri(uri: string): [string, string] {
+  static resolveUri(uri: string): [string, string, string] {
     return getAdapterClassFromUri(uri).resolveUri(uri);
   }
 }
@@ -150,7 +150,7 @@ function isUriFor<A extends Adapter>(
   });
 }
 
-function isTypeOf(
+export function isTypeOf(
   core: GmeContentContext["core"],
   node: Core.Node,
   name: string,

--- a/src/routers/Search/adapters/metadata.ts
+++ b/src/routers/Search/adapters/metadata.ts
@@ -181,7 +181,7 @@ export class StorageWithGraphSearch<
     }
   }
 
-  resolveUri(uri: string): [string, string] {
+  resolveUri(uri: string): [string, string, string] {
     return this.contentStore.resolveUri(uri);
   }
 

--- a/test/routers/Search/adapters/MongoDB/index.spec.js
+++ b/test/routers/Search/adapters/MongoDB/index.spec.js
@@ -181,41 +181,42 @@ describe("MongoDB", function () {
     });
 
     describe("resolveUri", function () {
-      const storageHostUri = 'mongoDoc://mongo:27017/udcp_taxonomy/udcp_provenance';
-      const repoId = '65ba9221db63515528bf54f8';
-      const repoUri = storageHostUri + '/' + repo;
-      const contentUri = repoUri + '/0_1';
+      const storageHostUri =
+        "mongoDoc://mongo:27017/udcp_taxonomy/udcp_provenance";
+      const repoId = "65ba9221db63515528bf54f8";
+      const repoUri = storageHostUri + "/" + repo;
+      const contentUri = repoUri + "/0_1";
 
       it("should resolve storageHostUri", function () {
         const [host, repo, content] = PDP.resolveUri(storageHostUri);
         assert.equal(host, storageHostUri);
-        assert.equal(repo, '');
-        assert.equal(content, '');
+        assert.equal(repo, "");
+        assert.equal(content, "");
       });
 
       it("should resolve repoUri", function () {
         const [host, repo, content] = PDP.resolveUri(repoUri);
         assert.equal(host, storageHostUri);
         assert.equal(repo, repoId);
-        assert.equal(content, '');
+        assert.equal(content, "");
       });
 
       it("should resolve storageHostUri", function () {
         const [host, repo, content] = PDP.resolveUri(contentUri);
         assert.equal(host, storageHostUri);
         assert.equal(repo, repoId);
-        assert.equal(content, '0_1');
+        assert.equal(content, "0_1");
       });
 
       it("should throw if no uri", function () {
         let didThrow = false;
         try {
-          PDP.resolveUri('mongoDoc://mongo:27017');
+          PDP.resolveUri("mongoDoc://mongo:27017");
         } catch {
           didThrow = true;
         }
 
-        assert(didThrow, 'Should have thrown');
+        assert(didThrow, "Should have thrown");
       });
     });
 

--- a/test/routers/Search/adapters/MongoDB/index.spec.js
+++ b/test/routers/Search/adapters/MongoDB/index.spec.js
@@ -180,6 +180,45 @@ describe("MongoDB", function () {
       );
     });
 
+    describe("resolveUri", function () {
+      const storageHostUri = 'mongoDoc://mongo:27017/udcp_taxonomy/udcp_provenance';
+      const repoId = '65ba9221db63515528bf54f8';
+      const repoUri = storageHostUri + '/' + repo;
+      const contentUri = repoUri + '/0_1';
+
+      it("should resolve storageHostUri", function () {
+        const [host, repo, content] = PDP.resolveUri(storageHostUri);
+        assert.equal(host, storageHostUri);
+        assert.equal(repo, '');
+        assert.equal(content, '');
+      });
+
+      it("should resolve repoUri", function () {
+        const [host, repo, content] = PDP.resolveUri(repoUri);
+        assert.equal(host, storageHostUri);
+        assert.equal(repo, repoId);
+        assert.equal(content, '');
+      });
+
+      it("should resolve storageHostUri", function () {
+        const [host, repo, content] = PDP.resolveUri(contentUri);
+        assert.equal(host, storageHostUri);
+        assert.equal(repo, repoId);
+        assert.equal(content, '0_1');
+      });
+
+      it("should throw if no uri", function () {
+        let didThrow = false;
+        try {
+          PDP.resolveUri('mongoDoc://mongo:27017');
+        } catch {
+          didThrow = true;
+        }
+
+        assert(didThrow, 'Should have thrown');
+      });
+    });
+
     it("should match against content URIs", async function () {
       const repoId = await mongo.withRepoReservation(async (res) => {
         const metadata = {

--- a/test/routers/Search/adapters/MongoDB/index.spec.js
+++ b/test/routers/Search/adapters/MongoDB/index.spec.js
@@ -184,25 +184,25 @@ describe("MongoDB", function () {
       const storageHostUri =
         "mongoDoc://mongo:27017/udcp_taxonomy/udcp_provenance";
       const repoId = "65ba9221db63515528bf54f8";
-      const repoUri = storageHostUri + "/" + repo;
+      const repoUri = storageHostUri + "/" + repoId;
       const contentUri = repoUri + "/0_1";
 
       it("should resolve storageHostUri", function () {
-        const [host, repo, content] = PDP.resolveUri(storageHostUri);
+        const [host, repo, content] = MongoDB.resolveUri(storageHostUri);
         assert.equal(host, storageHostUri);
         assert.equal(repo, "");
         assert.equal(content, "");
       });
 
       it("should resolve repoUri", function () {
-        const [host, repo, content] = PDP.resolveUri(repoUri);
+        const [host, repo, content] = MongoDB.resolveUri(repoUri);
         assert.equal(host, storageHostUri);
         assert.equal(repo, repoId);
         assert.equal(content, "");
       });
 
       it("should resolve storageHostUri", function () {
-        const [host, repo, content] = PDP.resolveUri(contentUri);
+        const [host, repo, content] = MongoDB.resolveUri(contentUri);
         assert.equal(host, storageHostUri);
         assert.equal(repo, repoId);
         assert.equal(content, "0_1");
@@ -211,7 +211,7 @@ describe("MongoDB", function () {
       it("should throw if no uri", function () {
         let didThrow = false;
         try {
-          PDP.resolveUri("mongoDoc://mongo:27017");
+          MongoDB.resolveUri("mongoDoc://mongo:27017");
         } catch {
           didThrow = true;
         }

--- a/test/routers/Search/adapters/PDP/index.spec.js
+++ b/test/routers/Search/adapters/PDP/index.spec.js
@@ -342,6 +342,45 @@ describe("PDP", function () {
     });
   });
 
+  describe("resolveUri", function () {
+    const storageHostUri = 'pdp://leappremonitiondev.azurewebsites.net/PROD_MODEL_ML';
+    const repoId = 'a8409436-2040-46c7-9310-ea23f7d29c25';
+    const repoUri = storageHostUri + '/' + repo;
+    const contentUri = repoUri + '/1/0';
+
+    it("should resolve storageHostUri", function () {
+      const [host, repo, content] = PDP.resolveUri(storageHostUri);
+      assert.equal(host, storageHostUri);
+      assert.equal(repo, '');
+      assert.equal(content, '');
+    });
+
+    it("should resolve repoUri", function () {
+      const [host, repo, content] = PDP.resolveUri(repoUri);
+      assert.equal(host, storageHostUri);
+      assert.equal(repo, repoId);
+      assert.equal(content, '');
+    });
+
+    it("should resolve storageHostUri", function () {
+      const [host, repo, content] = PDP.resolveUri(contentUri);
+      assert.equal(host, storageHostUri);
+      assert.equal(repo, repoId);
+      assert.equal(content, '1_0');
+    });
+
+    it("should throw if no uri", function () {
+      let didThrow = false;
+      try {
+        PDP.resolveUri('pdp://leappremonitiondev.azurewebsites.net');
+      } catch {
+        didThrow = true;
+      }
+
+      assert(didThrow, 'Should have thrown');
+    });
+  });
+
   describe("concurrent uploads", function () {
     let pdp;
     before(() => {

--- a/test/routers/Search/adapters/PDP/index.spec.js
+++ b/test/routers/Search/adapters/PDP/index.spec.js
@@ -346,7 +346,7 @@ describe("PDP", function () {
     const storageHostUri =
       "pdp://leappremonitiondev.azurewebsites.net/PROD_MODEL_ML";
     const repoId = "a8409436-2040-46c7-9310-ea23f7d29c25";
-    const repoUri = storageHostUri + "/" + repo;
+    const repoUri = storageHostUri + "/" + repoId;
     const contentUri = repoUri + "/1/0";
 
     it("should resolve storageHostUri", function () {

--- a/test/routers/Search/adapters/PDP/index.spec.js
+++ b/test/routers/Search/adapters/PDP/index.spec.js
@@ -343,41 +343,42 @@ describe("PDP", function () {
   });
 
   describe("resolveUri", function () {
-    const storageHostUri = 'pdp://leappremonitiondev.azurewebsites.net/PROD_MODEL_ML';
-    const repoId = 'a8409436-2040-46c7-9310-ea23f7d29c25';
-    const repoUri = storageHostUri + '/' + repo;
-    const contentUri = repoUri + '/1/0';
+    const storageHostUri =
+      "pdp://leappremonitiondev.azurewebsites.net/PROD_MODEL_ML";
+    const repoId = "a8409436-2040-46c7-9310-ea23f7d29c25";
+    const repoUri = storageHostUri + "/" + repo;
+    const contentUri = repoUri + "/1/0";
 
     it("should resolve storageHostUri", function () {
       const [host, repo, content] = PDP.resolveUri(storageHostUri);
       assert.equal(host, storageHostUri);
-      assert.equal(repo, '');
-      assert.equal(content, '');
+      assert.equal(repo, "");
+      assert.equal(content, "");
     });
 
     it("should resolve repoUri", function () {
       const [host, repo, content] = PDP.resolveUri(repoUri);
       assert.equal(host, storageHostUri);
       assert.equal(repo, repoId);
-      assert.equal(content, '');
+      assert.equal(content, "");
     });
 
     it("should resolve storageHostUri", function () {
       const [host, repo, content] = PDP.resolveUri(contentUri);
       assert.equal(host, storageHostUri);
       assert.equal(repo, repoId);
-      assert.equal(content, '1_0');
+      assert.equal(content, "1_0");
     });
 
     it("should throw if no uri", function () {
       let didThrow = false;
       try {
-        PDP.resolveUri('pdp://leappremonitiondev.azurewebsites.net');
+        PDP.resolveUri("pdp://leappremonitiondev.azurewebsites.net");
       } catch {
         didThrow = true;
       }
 
-      assert(didThrow, 'Should have thrown');
+      assert(didThrow, "Should have thrown");
     });
   });
 


### PR DESCRIPTION
Important! No trailing slashes...

Content-Type-Storage-Host-URI
`pdp://leappremonitiondev.azurewebsites.net/PROD_MODEL_ML`

Repository-URI
`pdp://leappremonitiondev.azurewebsites.net/PROD_MODEL_ML/a8409436-2040-46c7-9310-ea23f7d29c25`

Content-URI
`pdp://leappremonitiondev.azurewebsites.net/PROD_MODEL_ML/a8409436-2040-46c7-9310-ea23f7d29c25/1/0`

All three can be used to obtain a url to the dashboard using the search feature.